### PR TITLE
add option to keep query string in CSS url

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,12 +39,12 @@ function resolveUrlLoader(content, sourceMap) {
 
   // prefer loader query, else options object, else default values
   var options = defaults(loaderUtils.parseQuery(loader.query), loader.options[camelcase(PACKAGE_NAME)], {
-    absolute        : false,
-    sourceMap       : false,
-    fail            : false,
-    silent          : false,
-    keepQueryInUrl  : false,
-    root            : null
+    absolute  : false,
+    sourceMap : false,
+    fail      : false,
+    silent    : false,
+    keepQuery : false,
+    root      : null
   });
 
   // validate root directory
@@ -194,27 +194,21 @@ function resolveUrlLoader(content, sourceMap) {
         var mod = i % 7;
         if ((mod === 3) || (mod === 5)) {
 
-          // remove query string or hash suffix
-          var uri      = initialised.split(/[?#]/g).shift(),
-              absolute = uri && findFile.absolute(directory, uri, resolvedRoot);
-
-          var hasQuery = false, querySeperator = '';
-          var queryStr = initialised.split(/[?#]/g).pop();
-
-          hasQuery = (queryStr !== uri);
-          if (hasQuery) {
-            querySeperator = (initialised.indexOf('?#') === -1) ? ((initialised.indexOf('?') === -1) ? '#' : '?') : '?#';
-          }
+          // split into uri and query/hash and then find the absolute path to the uri
+          var split    = initialised.split(/([?#])/g),
+              uri      = split[0],
+              absolute = uri && findFile.absolute(directory, uri, resolvedRoot),
+              query    = options.keepQuery ? split.slice(1).join('') : '';
 
           // use the absolute path (or default to initialised)
           if (options.absolute) {
-            return absolute && absolute.replace(BACKSLASH_REGEX, '/').concat((hasQuery && options.keepQueryInUrl) ? querySeperator + queryStr : '') || initialised;
+            return absolute && absolute.replace(BACKSLASH_REGEX, '/').concat(query) || initialised;
           }
           // module relative path (or default to initialised)
           else {
             var relative     = absolute && path.relative(filePath, absolute),
                 rootRelative = relative && loaderUtils.urlToRequest(relative, '~');
-            return (rootRelative) ? rootRelative.replace(BACKSLASH_REGEX, '/').concat((hasQuery && options.keepQueryInUrl) ? querySeperator + queryStr : '') : initialised;
+            return (rootRelative) ? rootRelative.replace(BACKSLASH_REGEX, '/').concat(query) : initialised;
           }
         }
         // everything else, including parentheses and quotation (where present) and media statements

--- a/index.js
+++ b/index.js
@@ -39,11 +39,12 @@ function resolveUrlLoader(content, sourceMap) {
 
   // prefer loader query, else options object, else default values
   var options = defaults(loaderUtils.parseQuery(loader.query), loader.options[camelcase(PACKAGE_NAME)], {
-    absolute : false,
-    sourceMap: false,
-    fail     : false,
-    silent   : false,
-    root     : null
+    absolute        : false,
+    sourceMap       : false,
+    fail            : false,
+    silent          : false,
+    keepQueryInUrl  : false,
+    root            : null
   });
 
   // validate root directory
@@ -197,15 +198,23 @@ function resolveUrlLoader(content, sourceMap) {
           var uri      = initialised.split(/[?#]/g).shift(),
               absolute = uri && findFile.absolute(directory, uri, resolvedRoot);
 
+          var hasQuery = false, querySeperator = '';
+          var queryStr = initialised.split(/[?#]/g).pop();
+
+          hasQuery = (queryStr !== uri);
+          if (hasQuery) {
+            querySeperator = (initialised.indexOf('?#') === -1) ? ((initialised.indexOf('?') === -1) ? '#' : '?') : '?#';
+          }
+
           // use the absolute path (or default to initialised)
           if (options.absolute) {
-            return absolute && absolute.replace(BACKSLASH_REGEX, '/') || initialised;
+            return absolute && absolute.replace(BACKSLASH_REGEX, '/').concat((hasQuery && options.keepQueryInUrl) ? querySeperator + queryStr : '') || initialised;
           }
           // module relative path (or default to initialised)
           else {
             var relative     = absolute && path.relative(filePath, absolute),
                 rootRelative = relative && loaderUtils.urlToRequest(relative, '~');
-            return (rootRelative) ? rootRelative.replace(BACKSLASH_REGEX, '/') : initialised;
+            return (rootRelative) ? rootRelative.replace(BACKSLASH_REGEX, '/').concat((hasQuery && options.keepQueryInUrl) ? querySeperator + queryStr : '') : initialised;
           }
         }
         // everything else, including parentheses and quotation (where present) and media statements

--- a/readme.md
+++ b/readme.md
@@ -85,6 +85,8 @@ Where `...` is a hash of any of the following options.
 
 * `fail` Syntax or source-map errors will result in an error.
 
+* `keepQueryInUrl` Keep query string and hash within url. I.e. `url('./MyFont.eot?#iefix')`, `url('./MyFont.svg#oldiosfix')`.
+
 * `root` An optional directory within which search may be performed. Relative paths are permitted. Where omitted `process.cwd()` is used and should be sufficient for most use cases.
 
 Note that query parameters take precedence over programmatic parameters.

--- a/readme.md
+++ b/readme.md
@@ -85,7 +85,7 @@ Where `...` is a hash of any of the following options.
 
 * `fail` Syntax or source-map errors will result in an error.
 
-* `keepQueryInUrl` Keep query string and hash within url. I.e. `url('./MyFont.eot?#iefix')`, `url('./MyFont.svg#oldiosfix')`.
+* `keepQuery` Keep query string and hash within url. I.e. `url('./MyFont.eot?#iefix')`, `url('./MyFont.svg#oldiosfix')`.
 
 * `root` An optional directory within which search may be performed. Relative paths are permitted. Where omitted `process.cwd()` is used and should be sufficient for most use cases.
 


### PR DESCRIPTION
Currently resolve-url-loader strips off all query strings for CSS URLs.
There is a reason why coder would add query or hash to the end of URL, we should keep it.

For example. This is undesirable (meaning breaking :) ) when url is eot font with dummy query that is needed for IE. Sure, it is IE8, however we still want to get "update your browser" message using nice typeface. And Webpack is not only for top edge, you can pack ES3 apps with it :)

Consider

```scss
@font-face {
  font-family: 'myfontfamily';
  src: url('./MyFont.eot'); /* IE9 Compat Modes */
  src: url('./MyFont.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
       url('./MyFont.woff') format('woff'), /* Modern Browsers */
       url('./MyFont.ttf')  format('truetype'), /* Safari, Android, iOS */
       url('./MyFont.svg#3478686034630b6bbb8f4a5751bfe071') format('svg'); /* Legacy iOS */
  font-style:   normal;
  font-weight:  400;
}
```

So option to pass `keepQueryInUrl` is added, which I left to be false by default, so nobody that relies on the current behaviour would suffer.
`css-loader` and eventually `webpack` core down the road does not care about it, it just works. and both when `relative` (default) or `absolute` option is passed to resolve-url-loader.

```javascript
    {
      test: /\.(scss)$/,
      loader: production
      ? ExtractTextPlugin.extract('css-loader!postcss-loader!resolve-url-loader?keepQueryInUrl!sass-loader?sourceMap')
      : 'style-loader!css-loader?sourceMap!postcss-loader!resolve-url-loader?keepQueryInUrl!sass-loader?sourceMap'
    }
```

Please revise.
If all OK, please merge and bump npm package.

Regards,
kroko