### PR TITLE
Adjust resolve-url-loader to work with sass-loader 4.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,10 +104,11 @@ function resolveUrlLoader(content, sourceMap) {
   if (useMap) {
 
     // source-map sources seem to be relative to the file being processed
-    absoluteToRelative(reworked.map.sources, filePath);
+    absoluteToRelative(reworked.map.sources, path.resolve(filePath, sourceRoot));
     
     // Set source root again
     reworked.map.sourceRoot = sourceRoot;
+
     // need to use callback when there are multiple arguments
     loader.callback(null, reworked.code, reworked.map);
   }

--- a/index.js
+++ b/index.js
@@ -33,18 +33,19 @@ function resolveUrlLoader(content, sourceMap) {
   // details of the file being processed
   //  we would normally use compilation.getPath(options.output.path) to get the most correct outputPath,
   //  however we need to match to the sass-loader and it does not do so
-  var loader     = this,
-      filePath   = loader.context,
-      outputPath = path.resolve(loader.options.context);
+  var loader      = this,
+      filePath    = loader.context,
+      outputPath  = path.resolve(loader.options.output.path),
+      contextPath = path.resolve(loader.options.context);
 
   // prefer loader query, else options object, else default values
   var options = defaults(loaderUtils.parseQuery(loader.query), loader.options[camelcase(PACKAGE_NAME)], {
-    absolute  : false,
-    sourceMap : false,
-    fail      : false,
-    silent    : false,
-    keepQuery : false,
-    root      : null
+    absolute : false,
+    sourceMap: false,
+    fail     : false,
+    silent   : false,
+    keepQuery: false,
+    root     : null
   });
 
   // validate root directory
@@ -61,16 +62,27 @@ function resolveUrlLoader(content, sourceMap) {
   var sourceMapConsumer, contentWithMap, sourceRoot;
   if (sourceMap) {
 
-    // sass-loader outputs source-map sources relative to output directory so start our search there
+    // expect sass-loader@>=4.0.0
+    //  sourcemap sources relative to context path
     try {
-      relativeToAbsolute(sourceMap.sources, outputPath, resolvedRoot);
-      // There are now absolute paths in the source map so we don't need it anymore
-      // However, later when we go back to relative paths, we need to add it again
-      sourceRoot = sourceMap.sourceRoot;
-      sourceMap.sourceRoot = null;
-    } catch (exception) {
-      return handleException('source-map error', exception.message);
+      relativeToAbsolute(sourceMap.sources, contextPath, resolvedRoot);
     }
+    catch (unused) {
+
+      // fallback to sass-loader@<4.0.0
+      //  sourcemap sources relative to output path
+      try {
+        relativeToAbsolute(sourceMap.sources, outputPath, resolvedRoot);
+      }
+      catch (exception) {
+        return handleException('source-map error', exception.message);
+      }
+    }
+
+    // There are now absolute paths in the source map so we don't need it anymore
+    // However, later when we go back to relative paths, we need to add it again
+    sourceRoot = sourceMap.sourceRoot;
+    sourceMap.sourceRoot = undefined;
 
     // prepare the adjusted sass source-map for later look-ups
     sourceMapConsumer = new SourceMapConsumer(sourceMap);
@@ -105,7 +117,7 @@ function resolveUrlLoader(content, sourceMap) {
 
     // source-map sources seem to be relative to the file being processed
     absoluteToRelative(reworked.map.sources, path.resolve(filePath, sourceRoot));
-    
+
     // Set source root again
     reworked.map.sourceRoot = sourceRoot;
 
@@ -124,8 +136,9 @@ function resolveUrlLoader(content, sourceMap) {
    * @returns {string} The original CSS content
    */
   function handleException(label, exception) {
-    var rest = (typeof exception === 'string') ? [exception] : (exception instanceof Error) ? [exception.message,
-      exception.stack.split('\n')[1].trim()] : [];
+    var rest = (typeof exception === 'string') ? [exception] :
+               (exception instanceof Error) ? [exception.message, exception.stack.split('\n')[1].trim()] :
+               [];
     var message = '  resolve-url-loader cannot operate: ' + [label].concat(rest).filter(Boolean).join('\n  ');
     if (options.fail) {
       loader.emitError(message);

--- a/index.js
+++ b/index.js
@@ -116,7 +116,7 @@ function resolveUrlLoader(content, sourceMap) {
   if (useMap) {
 
     // source-map sources seem to be relative to the file being processed
-    absoluteToRelative(reworked.map.sources, path.resolve(filePath, sourceRoot));
+    absoluteToRelative(reworked.map.sources, path.resolve(filePath, sourceRoot || '.'));
 
     // Set source root again
     reworked.map.sourceRoot = sourceRoot;

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ function resolveUrlLoader(content, sourceMap) {
   });
 
   // validate root directory
-  var resolvedRoot = (typeof options.root === 'string') && path.resolve(options.root),
+  var resolvedRoot = (typeof options.root === 'string') && path.resolve(options.root) || undefined,
       isValidRoot  = resolvedRoot && fs.existsSync(resolvedRoot);
   if (options.root && !isValidRoot) {
     return handleException('"root" option does not resolve to a valid path');
@@ -119,8 +119,8 @@ function resolveUrlLoader(content, sourceMap) {
 
   /**
    * Push an error for the given exception and return the original content.
-   * @param {string} label
-   * @param {string|Error} exception
+   * @param {string} label Summary of the error
+   * @param {string|Error} [exception] Optional extended error details
    * @returns {string} The original CSS content
    */
   function handleException(label, exception) {

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ function resolveUrlLoader(content, sourceMap) {
   //  however we need to match to the sass-loader and it does not do so
   var loader     = this,
       filePath   = loader.context,
-      outputPath = path.resolve(loader.options.output.path);
+      outputPath = path.resolve(loader.options.context);
 
   // prefer loader query, else options object, else default values
   var options = defaults(loaderUtils.parseQuery(loader.query), loader.options[camelcase(PACKAGE_NAME)], {
@@ -58,12 +58,16 @@ function resolveUrlLoader(content, sourceMap) {
   loader.cacheable();
 
   // incoming source-map
-  var sourceMapConsumer, contentWithMap;
+  var sourceMapConsumer, contentWithMap, sourceRoot;
   if (sourceMap) {
 
     // sass-loader outputs source-map sources relative to output directory so start our search there
     try {
       relativeToAbsolute(sourceMap.sources, outputPath, resolvedRoot);
+      // There are now absolute paths in the source map so we don't need it anymore
+      // However, later when we go back to relative paths, we need to add it again
+      sourceRoot = sourceMap.sourceRoot;
+      sourceMap.sourceRoot = null;
     } catch (exception) {
       return handleException('source-map error', exception.message);
     }
@@ -101,7 +105,9 @@ function resolveUrlLoader(content, sourceMap) {
 
     // source-map sources seem to be relative to the file being processed
     absoluteToRelative(reworked.map.sources, filePath);
-
+    
+    // Set source root again
+    reworked.map.sourceRoot = sourceRoot;
     // need to use callback when there are multiple arguments
     loader.callback(null, reworked.code, reworked.map);
   }

--- a/lib/find-file.js
+++ b/lib/find-file.js
@@ -18,7 +18,7 @@ module.exports = {
  */
 function absolute(startPath, uri, limit) {
   var basePath = base(startPath, uri, limit);
-  return !!basePath && path.resolve(basePath, uri);
+  return !!basePath && path.resolve(basePath, uri) || null;
 }
 
 /**

--- a/lib/sources-relative-to-absolute.js
+++ b/lib/sources-relative-to-absolute.js
@@ -4,7 +4,8 @@
  */
 'use strict';
 
-var path = require('path');
+var path = require('path'),
+    urix = require('urix');
 
 var findFile = require('./find-file');
 
@@ -44,7 +45,9 @@ module.exports = function sourcesRelativeToAbsolute(sources, defaultBasePath, li
 
       // file was found, now resolve the absolute path
       if (basePath) {
-        array[i] = path.resolve(basePath, location);
+        // rework-css uses urix internally. If we don't convert the path here, the paths are messed up
+        // with the conversion relative urls are set correctly
+        array[i] = urix(path.resolve(basePath, location));
         return basePath;
       }
       // file not found implies an error

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "lodash.defaults": "^3.1.2",
     "rework": "^1.0.1",
     "rework-visit": "^1.0.0",
-    "source-map": "^0.1.43"
+    "source-map": "^0.1.43",
+    "urix": "^0.1.0"
   }
 }


### PR DESCRIPTION
This fixes #22. After the change in https://github.com/jtangelder/sass-loader/pull/250 source maps are not created in the output directory anymore. This is now done in the context directory. This changes the behavior and also fixes some path problems in source maps on windows.