### PR TITLE
parse the incoming sourcemap from string to json

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,6 +62,9 @@ function resolveUrlLoader(content, sourceMap) {
   var sourceMapConsumer, contentWithMap, sourceRoot;
   if (sourceMap) {
 
+    //when use less-loader the incoming sourceMap is string,need to parse it
+    sourceMap = typeof sourceMap == 'string' ? JSON.parse(sourceMap) : sourceMap;
+
     // expect sass-loader@>=4.0.0
     //  sourcemap sources relative to context path
     try {


### PR DESCRIPTION
When I use resolve-url-loader with less-loader like this:
`
{
    test: /\.less$/,
    loader: ExtractTextPlugin.extract("css-loader?sourceMap!resolve-url-loader?sourceMap!less-loader?sourceMap")
}
`
I found the incoming sourcemap is typeof string not Object.
So I must parse it from string to json that can use it well in conjunction with the less-loader in my  project.
