### PR TITLE
Support for less-loader

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ var PACKAGE_NAME = require('./package.json').name;
  * A webpack loader that resolves absolute url() paths relative to their original source file.
  * Requires source-maps to do any meaningful work.
  * @param {string} content Css content
- * @param {object} sourceMap The source-map
+ * @param {object|String} sourceMap The source-map
  * @returns {string|String}
  */
 function resolveUrlLoader(content, sourceMap) {
@@ -60,6 +60,8 @@ function resolveUrlLoader(content, sourceMap) {
 
   // incoming source-map
   var sourceMapConsumer, contentWithMap, sourceRoot;
+  // NOTE: source-map from the less-loader comes as string
+  sourceMap = (typeof sourceMap === 'string') ? JSON.parse(sourceMap) : sourceMap;
   if (sourceMap) {
 
     // expect sass-loader@>=4.0.0


### PR DESCRIPTION
Hi,
thanks for writing this loader, it helps me a lot in the migration of older project with Grunt build to Webpack. 
I tried to use it after a less-loader and it was failing with error 'Source map not available'. After some debugging I noticed that the source map from the less-loader comes as string while in the code it's expected as object. So simple JSON.parse did the job. :)

Cheers!