### PR TITLE
Improved search

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,13 +37,14 @@ function resolveUrlLoader(content, sourceMap) {
   // webpack 1: prefer loader query, else options object
   // webpack 2; prefer loader options
   var options = defaults(loaderUtils.getOptions(loader), loader.options[camelcase(PACKAGE_NAME)], {
-    absolute : false,
-    sourceMap: loader.sourceMap,
-    fail     : false,
-    silent   : false,
-    keepQuery: false,
-    debug    : false,
-    root     : null
+    absolute   : false,
+    sourceMap  : loader.sourceMap,
+    fail       : false,
+    silent     : false,
+    keepQuery  : false,
+    debug      : false,
+    root       : null,
+    includeRoot: false
   });
 
   // validate root directory

--- a/lib/find-file.js
+++ b/lib/find-file.js
@@ -60,7 +60,8 @@ function findFile(opt) {
       } while (isWorking);
 
       // start a queue with the path to the root
-      var queue = pathToRoot.concat();
+      var appendLimit = options.includeRoot && pathToRoot.indexOf(limit) === -1 ? limit : [];
+      var queue = pathToRoot.concat(appendLimit);
 
       // process the queue until empty
       //  the queue pattern ensures that we favour paths closest the the start path


### PR DESCRIPTION
Hello, I have made little improvement for search. Let say you have this webpack dev config: 
```
const devConfig = {
  // some code
  module: {
    rules: [
      {
        test: /\.(sass|scss)$/,
        use: [
          'style-loader',
          'css-loader',
          'postcss-loader',
	  'resolve-url-loader',
	  {
            loader: 'sass-loader',
            options: {
              sourceMap: true
            }
          }
        ]
      },
      {
        test: /\.less$/,
        use: [
          'style-loader',
          'css-loader',
          'postcss-loader',
          'resolve-url-loader',
	  {
            loader: 'stylus-loader',
            options: {
              sourceMap: true
              use: [require('nib')()],
              import: ['~nib/lib/nib/index.styl']
            }
          }
        ]
      }
    ]
  }
};
```
Sass files will work just fine, but stylus wouldn't. Because stylus has plugin nib that located in node_modules. The problem in this function: **testNotPackage(absoluteStart)**. When building _queue_ with _limit = 'my-project/'_ we have such results:
```
/my-project/node_modules/nib/lib/nib
/my-project/node_modules/nib/lib
/my-project/node_modules/nib
/my-project/node_modules/nib/lib/nib/normalize
/my-project/node_modules/nib/lib/nib/text
/my-project/node_modules/nib/lib/nodes
/my-project/node_modules/nib/docs
/my-project/node_modules/nib/iconic
/my-project/node_modules/nib/node_modules
```
Search stops at _/my-project/node_modules/nib_ and dont go up to _limit_ because folder nib has package.json. My proposal to remove **testNotPackage(absoluteStart)** and fix this very old stylus/nib problem.