### PR TITLE
limit file search by `attempts` option (back-port to v2)

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ function resolveUrlLoader(content, sourceMap) {
     fail       : false,
     silent     : false,
     keepQuery  : false,
+    attempts   : 0,
     debug      : false,
     root       : null,
     includeRoot: false

--- a/lib/find-file.js
+++ b/lib/find-file.js
@@ -8,11 +8,12 @@ var PACKAGE_NAME = require('../package.json').name;
 
 /**
  * Factory for find-file with the given <code>options</code> hash.
- * @param {{debug: boolean}} [opt] Optional options hash
+ * @param {{debug: boolean, attempts:number}} [opt] Optional options hash
  */
 function findFile(opt) {
   var options = defaults(opt, {
-    debug: false
+    debug: false,
+    attempts: 0
   });
   return {
     absolute: absolute,
@@ -46,6 +47,9 @@ function findFile(opt) {
     // ensure we have some limit to the search
     limit = limit && path.resolve(limit) || process.cwd();
 
+    // #69 limit searching: make at least one attempt
+    var remaining = Math.max(0, options.attempts) || 1E+9;
+
     // ignore explicit uris data|http|https and ensure we are at a valid start path
     var absoluteStart = !(/^(data|https?):/.test(uri)) && path.resolve(startPath);
     if (absoluteStart) {
@@ -63,9 +67,9 @@ function findFile(opt) {
       var appendLimit = options.includeRoot && pathToRoot.indexOf(limit) === -1 ? limit : [];
       var queue = pathToRoot.concat(appendLimit);
 
-      // process the queue until empty
-      //  the queue pattern ensures that we favour paths closest the the start path
-      while (queue.length) {
+      // the queue pattern ensures that we favour paths closest the the start path
+      // process the queue until empty or until we exhaust our attempts
+      while (queue.length && (remaining-- > 0)) {
 
         // shift the first item off the queue, consider it the base for our relative uri
         var basePath = queue.shift();
@@ -83,9 +87,15 @@ function findFile(opt) {
         }
       }
 
+      // interrupted by options.attempts
+      if (queue.length) {
+        flushMessages('NOT FOUND (INTERRUPTED)');
+      }
       // not found
-      flushMessages('NOT FOUND');
-      return null;
+      else {
+        flushMessages('NOT FOUND');
+        return null;
+      }
     }
     // ignored
     else {

--- a/readme.md
+++ b/readme.md
@@ -119,7 +119,7 @@ There are some additional hacks available without support. Only do this if you k
 * `absolute` Forces the url() to be resolved to an absolute path. This is considered 
 [bad practice](http://webpack.github.io/docs/how-to-write-a-loader.html#should-not-embed-absolute-paths).
 
-* `includeRoot` (experimental, non-performant) Include the project `root` in file search. The `root` option need **not** be specified.
+* `includeRoot` (experimental, non-performant) Include the project `root` in file search. The `root` option need not be specified but `includeRoot` is only really useful if your `root` directory is shallower than your build working directory.
 
 Note that query parameters take precedence over programmatic parameters.
 
@@ -129,17 +129,19 @@ A [rework](https://github.com/reworkcss/rework) process is run on incoming CSS.
 
 Each `url()` statement that implies an asset triggers a file search using node `fs` operations. The asset should be relative to the original source file that was transpiled. This original source is determined by consulting the incoming source-map at the point of the `url()` statement.
 
-Usually the asset is found relative to the original source file `O(1)`. However in some cases there is no immediate match (*cough* bootstrap *cough*) and we so we start searching both deeper and shallower from the starting directory `O(n)`. Note that `n` may be limited by the `attempts` option.
+Usually the asset is found relative to the original source file `O(1)`.
+
+However in cases where there is no immediate match, we start searching both deeper and shallower from the starting directory `O(n)`. Note that `n` may be limited by the `attempts` option.
+
+This file search "magic" is mainly for historic reasons, to work around broken packages whose assets are not where we would expect.
 
 Shallower paths must be limited to avoid the whole file system from being considered. Progressively shallower paths within the `root` will be considered. Paths featuring a `package.json` or `bower.json` file will not be considered.
-
-* This effectively excludes your project root (except where `options.includeRoot`).
-* Search in a project subdirectory will not escape that subdirectory (except where`options.includeRoot`).
-* Search of a package in `node_modules` will not escape that package.
 
 If the asset is not found then the `url()` statement will not be updated with a Webpack module-relative path. However if the `url()` statement has no source-map `source` information the loader will fail.
 
 The loader will also fail when input source-map `sources` cannot all be resolved relative to some consistent path within `root`.
+
+Use the `debug` option to see exactly what paths are being searched.
 
 ## Limitations / Known-issues
 
@@ -147,7 +149,7 @@ The loader will also fail when input source-map `sources` cannot all be resolved
 
 Failure to find an asset will trigger a file search of your project.
 
-This feature was for historic reasons, to work around broken packages. It is less relevant now and many users may not be aware of it.
+This feature was for historic reasons, to work around broken packages, whose assets are not where we would expect. Such problems are rare now and many users may not be aware of the search feature.
 
 We now have the `attempts` option to limit this feature. However by default it is unlimited (`attempts=0`) which could make your build non-performant.
 

--- a/readme.md
+++ b/readme.md
@@ -102,6 +102,8 @@ Where `...` is a hash of any of the following options.
 
 * `sourceMap` Generate a source-map.
 
+* `attempts` Limit searching for any files not where they are expected to be. This is unlimited by default so you will want to set it `1` or some small value.
+
 * `silent` Do not display warnings on CSS syntax or source-map error.
 
 * `fail` Syntax or source-map errors will result in an error.
@@ -127,7 +129,7 @@ A [rework](https://github.com/reworkcss/rework) process is run on incoming CSS.
 
 Each `url()` statement that implies an asset triggers a file search using node `fs` operations. The asset should be relative to the original source file that was transpiled. This original source is determined by consulting the incoming source-map at the point of the `url()` statement.
 
-Usually the asset is found relative to the original source file `O(1)`. However in some cases there is no immediate match (*cough* bootstrap *cough*) and we so we start searching both deeper and shallower from the starting directory `O(n)`.
+Usually the asset is found relative to the original source file `O(1)`. However in some cases there is no immediate match (*cough* bootstrap *cough*) and we so we start searching both deeper and shallower from the starting directory `O(n)`. Note that `n` may be limited by the `attempts` option.
 
 Shallower paths must be limited to avoid the whole file system from being considered. Progressively shallower paths within the `root` will be considered. Paths featuring a `package.json` or `bower.json` file will not be considered.
 
@@ -140,6 +142,17 @@ If the asset is not found then the `url()` statement will not be updated with a 
 The loader will also fail when input source-map `sources` cannot all be resolved relative to some consistent path within `root`.
 
 ## Limitations / Known-issues
+
+### File search "magic"
+
+Failure to find an asset will trigger a file search of your project.
+
+This feature was for historic reasons, to work around broken packages. It is less relevant now and many users may not be aware of it.
+
+We now have the `attempts` option to limit this feature. However by default it is unlimited (`attempts=0`) which could make your build non-performant.
+
+You should explicitly set `attempts=1` and increase the value only if needed. We will look to make this the default in the next major release.
+
 
 ### Mixins
 


### PR DESCRIPTION
Back-port the `attempts` option to v2. See #69 and #70.

Changes should be minimal to guarantee (by inspection) non-breaking enhancement.