### PR TITLE
--dev is deprecated in npm. --save-dev is (one of) the current ways.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ This loader will use the source-map from the SASS compiler to locate the origina
 yarn add resolve-url-loader --dev
 
 # via npm
-npm install --save resolve-url-loader --dev
+npm install resolve-url-loader --save-dev
 ```
 
 


### PR DESCRIPTION
Fixes the install command for npm. Current command is deprecated and results in install to dependencies instead of dev dependencies.