### PR TITLE
replace rework css with postcss

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
     "convert-source-map": "^1.1.1",
     "loader-utils": "^1.0.0",
     "lodash.defaults": "^4.0.0",
-    "rework": "^1.0.1",
-    "rework-visit": "^1.0.0",
+    "postcss": "^6.0.17",
     "source-map": "^0.5.6",
     "urix": "^0.1.0"
   }


### PR DESCRIPTION
Hi, I just came across the problem mentioned in #28 , and i found a lots of issues with the same problem that caused by `rework`, so i simply fork this repo and replace `rework` with `postcss`(which used by `css-loader`). However, just one second before i send this PR, i noticed that there is a branch trying to have multiple engines, so i wonder should i send you another PR to write a `postcss` engine?

In my point of view, it is 4 years since the last update of `rework`, so maybe we should simply drop it. Also, as `css-loader` is also using `postcss` as its parser, it can ensure that the CSS Module syntax won't cause any issues any more.