### PR TITLE
Update lodash to remove prototype vulnerabilities

### DIFF
--- a/packages/resolve-url-loader/index.js
+++ b/packages/resolve-url-loader/index.js
@@ -8,7 +8,7 @@ var path              = require('path'),
     fs                = require('fs'),
     loaderUtils       = require('loader-utils'),
     camelcase         = require('camelcase'),
-    defaults          = require('lodash.defaults'),
+    defaults          = require('lodash/defaults'),
     SourceMapConsumer = require('source-map').SourceMapConsumer;
 
 var adjustSourceMap = require('adjust-sourcemap-loader/lib/process');

--- a/packages/resolve-url-loader/package.json
+++ b/packages/resolve-url-loader/package.json
@@ -39,7 +39,7 @@
     "convert-source-map": "^1.5.1",
     "es6-iterator": "^2.0.3",
     "loader-utils": "^1.1.0",
-    "lodash.defaults": "^4.0.0",
+    "lodash": "^4.17.11",
     "postcss": "^7.0.0",
     "rework": "^1.0.1",
     "rework-visit": "^1.0.0",


### PR DESCRIPTION
Fixes https://github.com/bholloway/resolve-url-loader/issues/109 by removing prototype vulnerabilities for lodash.defaults.

https://ossindex.sonatype.org/component/pkg:npm/lodash.defaults