### PR TITLE
postcss multi-value engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,20 +14,20 @@
   "devDependencies": {
     "blue-tape": "1.0.0",
     "compose-function": "3.0.3",
-    "cross-env": "5.2.0",
-    "es6-promisify": "6.0.1",
+    "cross-env": "5.2.1",
+    "es6-promisify": "6.0.2",
     "escape-string-regexp": "1.0.5",
     "get-value": "3.0.1",
     "has-prop": "0.1.2",
-    "joi": "12.0.0",
-    "jshint": "2.10.1",
+    "joi": "14.3.1",
+    "jshint": "2.10.2",
     "micromatch": "3.1.10",
-    "ms": "2.1.1",
+    "ms": "2.1.2",
     "outdent": "0.7.0",
     "promise-compose": "1.1.2",
     "recursive-readdir": "2.2.2",
     "tap-diff": "0.1.1",
-    "vlq": "1.0.0"
+    "vlq": "1.0.1"
   },
   "engines": {
     "node": ">=6.0.0"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   ],
   "scripts": {
     "lint": "jshint packages --exclude **/node_modules",
-    "test:unit": "tape **/*.spec.js | tap-diff",
+    "test:unit": "tape **/*.test.js | tap-diff",
     "test:e2e": "tape test | tap-diff",
     "debug:e2e": "node $NODE_DEBUG_OPTION $(npm bin)/tape test | tap-diff"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,10 @@
 {
+  "name": "resolve-url-loader",
+  "description": "monorepo of all things resolve-url-loader",
+  "private": true,
   "author": "bholloway",
   "license": "MIT",
-  "private": true,
+  "main": "packages/resolve-url-loader",
   "workspaces": [
     "packages/*"
   ],

--- a/packages/resolve-url-loader/lib/join-function.js
+++ b/packages/resolve-url-loader/lib/join-function.js
@@ -67,14 +67,11 @@ function createJoinForPredicate(predicate, name) {
      * For absolute uri only `uri` will be provided. In this case we substitute any `root` given in options.
      *
      * @param {string} uri A uri path, relative or absolute
-     * @param {string|Iterator.<string>} [baseOrIteratorOrAbsent] Optional absolute base path or iterator thereof
+     * @param {Iterator.<string>} [maybeIterator] Optional iterator of absolute base path strings
      * @return {string} Just the uri where base is empty or the uri appended to the base
      */
-    return function joinProper(uri, baseOrIteratorOrAbsent) {
-      var iterator =
-        (typeof baseOrIteratorOrAbsent === 'undefined') && new Iterator([options.root          ]) ||
-        (typeof baseOrIteratorOrAbsent === 'string'   ) && new Iterator([baseOrIteratorOrAbsent]) ||
-        baseOrIteratorOrAbsent;
+    return function joinProper(uri, maybeIterator) {
+      var iterator = typeof maybeIterator === 'undefined' ? new Iterator([options.root]) : maybeIterator;
 
       var result = runIterator([]);
       log(createJoinMsg, [filename, uri, result, result.isFound]);

--- a/packages/resolve-url-loader/lib/join-function.js
+++ b/packages/resolve-url-loader/lib/join-function.js
@@ -67,7 +67,7 @@ function createJoinForPredicate(predicate, name) {
      * For absolute uri only `uri` will be provided. In this case we substitute any `root` given in options.
      *
      * @param {string} uri A uri path, relative or absolute
-     * @param {Iterator.<string>} [maybeIterator] Optional iterator of absolute base path strings
+     * @param {Iterator<string>} [maybeIterator] Optional iterator of absolute base path strings
      * @return {string} Just the uri where base is empty or the uri appended to the base
      */
     return function joinProper(uri, maybeIterator) {
@@ -125,7 +125,7 @@ exports.createJoinForPredicate = createJoinForPredicate;
  *
  * @param {string} file The file being processed by webpack
  * @param {string} uri A uri path, relative or absolute
- * @param {Array.<string>} bases Absolute base paths up to and including the found one
+ * @param {string[]} bases Absolute base paths up to and including the found one
  * @param {boolean} isFound Indicates the last base was correct
  * @return {string} Formatted message
  */

--- a/packages/resolve-url-loader/lib/position-algerbra.js
+++ b/packages/resolve-url-loader/lib/position-algerbra.js
@@ -1,0 +1,62 @@
+/*
+ * MIT License http://opensource.org/licenses/MIT
+ * Author: Ben Holloway @bholloway
+ */
+'use strict';
+
+/**
+ * Given a sourcemap position create a new maybeObject with only line and column properties.
+ *
+ * @param {*|{line: number, column: number}} maybeObj Possible location hash
+ * @returns {{line: number, column: number}} Location hash with possible NaN values
+ */
+function sanitise(maybeObj) {
+  var obj = !!maybeObj && typeof maybeObj === 'object' && maybeObj || {};
+  return {
+    line: isNaN(obj.line) ? NaN : obj.line,
+    column: isNaN(obj.column) ? NaN : obj.column
+  };
+}
+
+exports.sanitise = sanitise;
+
+/**
+ * Infer a line and position delta based on the linebreaks in the given string.
+ *
+ * @param candidate {string} A string with possible linebreaks
+ * @returns {{line: number, column: number}} A position object where line and column are deltas
+ */
+function strToOffset(candidate) {
+  var split = candidate.split(/\r\n|\n/g);
+  var last  = split[split.length - 1];
+  return {
+    line: split.length - 1,
+    column: last.length
+  };
+}
+
+exports.strToOffset = strToOffset;
+
+/**
+ * Add together a list of position elements.
+ *
+ * Lines are added. If the new line is zero the column is added otherwise it is overwritten.
+ *
+ * @param {{line: number, column: number}[]} list One or more sourcemap position elements to add
+ * @returns {{line: number, column: number}} Resultant position element
+ */
+function add(list) {
+  return list
+    .slice(1)
+    .reduce(
+      function (accumulator, element) {
+        return {
+          line: accumulator.line + element.line,
+          column: element.line > 0 ? element.column : accumulator.column + element.column,
+        };
+      },
+      list[0]
+    );
+}
+
+exports.add = add;

--- a/packages/resolve-url-loader/lib/position-algerbra.test.js
+++ b/packages/resolve-url-loader/lib/position-algerbra.test.js
@@ -1,0 +1,81 @@
+/*
+ * MIT License http://opensource.org/licenses/MIT
+ * Author: Ben Holloway @bholloway
+ */
+'use strict';
+
+const {basename} = require('path');
+const tape = require('blue-tape');
+
+const {sanitise, strToOffset, add} = require('./position-algerbra');
+
+const json = (strings, ...substitutions) =>
+  String.raw(
+    strings,
+    ...substitutions.map(v => JSON.stringify(v, (_, vv) => Number.isNaN(vv) ? 'NaN' : vv))
+  );
+
+tape(
+  basename(require.resolve('./position-algerbra')),
+  ({name, test, end: end1, equal}) => {
+    test(`${name} / sanitise()`, ({ end: end2 }) => {
+      [
+        [undefined, {line: NaN, column: NaN}],
+        [null, {line: NaN, column: NaN}],
+        [false, {line: NaN, column: NaN}],
+        [true, {line: NaN, column: NaN}],
+        [12, {line: NaN, column: NaN}],
+        [{}, {line: NaN, column: NaN}],
+        [{line: 1}, {line: 1, column: NaN}],
+        [{column: 1}, {line: NaN, column: 1}],
+      ].forEach(([input, expected]) =>
+        equal(
+          json`${sanitise(input)}`,
+          json`${expected}`,
+          json`input ${input} should sanitise to ${expected}`
+        )
+      );
+
+      end2();
+    });
+
+    test(`${name} / strToOffset()`, ({ end: end2 }) => {
+      [
+        ['', {line: 0, column: 0}],
+        ['something', {line: 0, column: 9}],
+        ['another\nthing', {line: 1, column: 5}],
+        ['a\r\nthird\nthingie', {line: 2, column: 7}],
+        ['a\r\nthird\rthingie', {line: 1, column: 13}],
+      ].forEach(([input, expected]) =>
+        equal(
+          json`${strToOffset(input)}`,
+          json`${expected}`,
+          json`input ${input} should convert to ${expected}`
+        )
+      );
+
+      end2();
+    });
+
+    test(`${name} / add()`, ({ end: end2 }) => {
+      [
+        [[{line: 0, column: 2}, {line: 0, column: 3}], {line: 0, column: 5}],
+        [[{line: 0, column: 2}, {line: 1, column: 3}], {line: 1, column: 3}],
+        [[{line: 1, column: 2}, {line: 0, column: 3}], {line: 1, column: 5}],
+        [[{line: 1, column: 2}, {line: 2, column: 3}], {line: 3, column: 3}],
+        [[{line: NaN, column: NaN}, {line: 0, column: 3}], {line: NaN, column: NaN}],
+        [[{line: NaN, column: NaN}, {line: 2, column: 3}], {line: NaN, column: 3}]
+      ].forEach(([input, expected]) =>
+        equal(
+          json`${add(input)}`,
+          json`${expected}`,
+          json`input ${input} should add to give ${expected}`
+        )
+      );
+
+      end2();
+    });
+
+    end1();
+  }
+);

--- a/packages/resolve-url-loader/package.json
+++ b/packages/resolve-url-loader/package.json
@@ -30,7 +30,7 @@
   },
   "files": [
     "index.js",
-    "lib"
+    "lib/**/+([a-z-]).js"
   ],
   "scripts": {
     "lint": "jshint --exclude **/node_modules index.js lib"

--- a/packages/resolve-url-loader/package.json
+++ b/packages/resolve-url-loader/package.json
@@ -37,12 +37,12 @@
   },
   "dependencies": {
     "adjust-sourcemap-loader": "2.0.0",
-    "camelcase": "5.0.0",
+    "camelcase": "5.3.1",
     "compose-function": "3.0.3",
     "convert-source-map": "1.6.0",
     "es6-iterator": "2.0.3",
     "loader-utils": "1.2.3",
-    "postcss": "7.0.14",
+    "postcss": "7.0.18",
     "rework": "1.0.1",
     "rework-visit": "1.0.0",
     "source-map": "0.6.1"

--- a/packages/test-my-cli/lib/promise.js
+++ b/packages/test-my-cli/lib/promise.js
@@ -29,7 +29,7 @@ exports.withTime = (next) => (...v) => {
  * a second argument to each function in the sequence. Additional arguments to the overall function
  * are available as additional arguments to each function.
  *
- * @param {string|function|Array.<string|function>} gets The field to get or a getter function
+ * @param {string|function|(string|function)[]} gets The field to get or a getter function
  * @param {string|function} set The field to set or a setter function
  * @return {function(...function):function(...*):Promise}
  */

--- a/packages/test-my-cli/operations/test.js
+++ b/packages/test-my-cli/operations/test.js
@@ -29,12 +29,22 @@ exports.create = (name, fn) => {
     'the test implementation function'
   );
 
+  // find the shallowest absolute filename in the call stack
+  const callerFilename = new Error().stack
+    .match(/\(((?:\w\:)?[\\\/][^)]+)\)/g)
+    .pop();
+
   return compose(operation(NAME, name), sequence)(
     assertInOperation(`misuse: ${NAME}() somehow escaped the operation`),
     (context0, {onActivity}, log) => {
       const {test: test0} = context0;
+      const {assertCount, pass} = test0;
 
       onActivity();
+
+      const maybeAssertFilename = (assertCount > 0) ?
+        () => pass(callerFilename) :
+        () => {};
 
       const innerTestWithOuterContext = (test1) =>
         assign({}, context0, {test: test1});
@@ -53,6 +63,7 @@ exports.create = (name, fn) => {
         `${test0.name}/${name}`,
         (t) => Promise.resolve(t)
           .then(onActivity)
+          .then(lens(null, null)(maybeAssertFilename))
           .then(lens(innerTestWithOuterContext, outerTestWithInnerContext)(fn))
           .then(resolve)
           .catch(reject)

--- a/packages/test-my-cli/package.json
+++ b/packages/test-my-cli/package.json
@@ -25,18 +25,18 @@
   "dependencies": {
     "compose-function": "3.0.3",
     "cross-spawn": "6.0.5",
-    "es6-promisify": "6.0.1",
+    "es6-promisify": "6.0.2",
     "get-value": "3.0.1",
-    "joi": "12.0.0",
+    "joi": "14.3.1",
     "micromatch": "3.1.10",
     "mkdirp": "0.5.1",
-    "ms": "2.1.1",
-    "object-path-immutable": "3.0.0",
+    "ms": "2.1.2",
+    "object-path-immutable": "4.0.1",
     "object.entries": "1.1.0",
     "object.values": "1.1.0",
     "promise-compose": "1.1.2",
     "recursive-readdir": "2.2.2",
-    "rimraf": "2.6.3",
+    "rimraf": "3.0.0",
     "string.prototype.padstart": "3.0.0"
   }
 }

--- a/test/cases/absolute-asset.js
+++ b/test/cases/absolute-asset.js
@@ -113,7 +113,7 @@ const assertSourcemapProd = sequence(
         return outdent`
           /src/feature/index.scss
             1:1
-            2:3->1:57 2:3->1:18
+            2:3->1:18 2:3->1:57
             3:3->1:57 3:3->1:96
             4:3->1:96 4:3->1:128
             5:3->1:128 5:3->1:157

--- a/test/cases/adjacent-asset.js
+++ b/test/cases/adjacent-asset.js
@@ -102,7 +102,7 @@ const assertSourcemapProd = sequence(
         return outdent`
           /src/feature/index.scss
             1:1
-            2:3->1:69 2:3->1:18
+            2:3->1:18 2:3->1:69
             3:3->1:69 3:3->1:120
             4:3->1:120 4:3->1:164
             5:3->1:164 5:3->1:205

--- a/test/cases/declaration-mixin.postcss.js
+++ b/test/cases/declaration-mixin.postcss.js
@@ -1,0 +1,266 @@
+'use strict';
+
+const {join} = require('path');
+const compose = require('compose-function');
+const outdent = require('outdent');
+const {test, layer, fs, env, cwd} = require('test-my-cli');
+
+const {trim} = require('../lib/util');
+const {withCacheBase} = require('../lib/higher-order');
+const {testDefault, testDebug, testWithLabel} = require('./common/tests');
+const {buildDevNormal, buildDevNoUrl, buildProdNormal, buildProdNoUrl, buildProdNoDevtool} = require('./common/builds');
+const {moduleNotFound} = require('./common/partials');
+const {
+  assertWebpackOk, assertNoErrors, assertNoMessages, assertContent, assertNoSourceMap, assertAssetUrls,
+  assertAssetFiles, assertStdout
+} = require('../lib/assert');
+
+const assertContentDev = compose(assertContent(/;\s*}/g, ';\n}'), outdent)`
+  .some-class-name {
+    background-image: url($0);
+  }
+  `;
+
+const assertContentProd = compose(assertContent(), trim)`
+  .some-class-name{background-image: url($0)}
+  `;
+
+const assertIncludeMessages = assertStdout('debug')(1)`
+  ^resolve-url-loader:[^:]+:[ ]*${'img.jpg'}
+  [ ]+${'./src/feature'}
+  [ ]+${'./src'}
+  [ ]+FOUND$
+  `;
+
+const assertMixinMessages = assertStdout('debug')(1)`
+  ^resolve-url-loader:[^:]+:[ ]*${'img.jpg'}
+  [ ]+${'./src/feature'}
+  [ ]+FOUND$
+  `;
+
+module.exports = test(
+  'declaration-mixin',
+  layer('declaration-mixin')(
+    cwd('.'),
+    fs({
+      'package.json': withCacheBase('package.json'),
+      'webpack.config.js': withCacheBase('webpack.config.js'),
+      'node_modules': withCacheBase('node_modules'),
+      'src/index.scss': outdent`
+          @import "feature/mixins.scss";
+          .some-class-name {
+            @include feature;
+          }
+          `,
+      'src/feature/mixins.scss': outdent`
+          @mixin feature {
+            background-image: url('img.jpg');
+          }
+          `,
+    }),
+    env({
+      ENTRY: join('src', 'index.scss')
+    }),
+    testWithLabel('asset-missing')(
+      moduleNotFound
+    ),
+    testWithLabel('asset-include')(
+      fs({
+        'src/img.jpg': require.resolve('./assets/blank.jpg')
+      }),
+      testDefault(
+        buildDevNormal(
+          assertWebpackOk,
+          assertNoErrors,
+          assertNoMessages,
+          assertContentDev,
+          // assertSourceMapSources,
+          assertAssetUrls(['d68e763c825dc0e388929ae1b375ce18.jpg']),
+          assertAssetFiles(['d68e763c825dc0e388929ae1b375ce18.jpg'])
+        ),
+        buildDevNoUrl(
+          assertWebpackOk,
+          assertNoErrors,
+          assertNoMessages,
+          assertContentDev,
+          // assertSourcemapDev,
+          assertAssetUrls(['./img.jpg']),
+          assertAssetFiles(false)
+        ),
+        buildProdNormal(
+          assertWebpackOk,
+          assertNoErrors,
+          assertNoMessages,
+          assertContentProd,
+          // assertSourceMapSources,
+          assertAssetUrls(['d68e763c825dc0e388929ae1b375ce18.jpg']),
+          assertAssetFiles(['d68e763c825dc0e388929ae1b375ce18.jpg'])
+        ),
+        buildProdNoUrl(
+          assertWebpackOk,
+          assertNoErrors,
+          assertNoMessages,
+          assertContentProd,
+          // assertSourcemapProd,
+          assertAssetUrls(['./img.jpg']),
+          assertAssetFiles(false)
+        ),
+        buildProdNoDevtool(
+          assertWebpackOk,
+          assertNoErrors,
+          assertNoMessages,
+          assertContentProd,
+          assertNoSourceMap,
+          assertAssetUrls(['d68e763c825dc0e388929ae1b375ce18.jpg']),
+          assertAssetFiles(['d68e763c825dc0e388929ae1b375ce18.jpg'])
+        )
+      ),
+      testDebug(
+        buildDevNormal(
+          assertWebpackOk,
+          assertNoErrors,
+          assertIncludeMessages,
+          assertContentDev,
+          // assertSourceMapSources,
+          assertAssetUrls(['d68e763c825dc0e388929ae1b375ce18.jpg']),
+          assertAssetFiles(['d68e763c825dc0e388929ae1b375ce18.jpg'])
+        ),
+        buildDevNoUrl(
+          assertWebpackOk,
+          assertNoErrors,
+          assertIncludeMessages,
+          assertContentDev,
+          // assertSourcemapDev,
+          assertAssetUrls(['./img.jpg']),
+          assertAssetFiles(false)
+        ),
+        buildProdNormal(
+          assertWebpackOk,
+          assertNoErrors,
+          assertIncludeMessages,
+          assertContentProd,
+          // assertSourceMapSources,
+          assertAssetUrls(['d68e763c825dc0e388929ae1b375ce18.jpg']),
+          assertAssetFiles(['d68e763c825dc0e388929ae1b375ce18.jpg'])
+        ),
+        buildProdNoUrl(
+          assertWebpackOk,
+          assertNoErrors,
+          assertIncludeMessages,
+          assertContentProd,
+          // assertSourcemapProd,
+          assertAssetUrls(['./img.jpg']),
+          assertAssetFiles(false)
+        ),
+        buildProdNoDevtool(
+          assertWebpackOk,
+          assertNoErrors,
+          assertIncludeMessages,
+          assertContentProd,
+          assertNoSourceMap,
+          assertAssetUrls(['d68e763c825dc0e388929ae1b375ce18.jpg']),
+          assertAssetFiles(['d68e763c825dc0e388929ae1b375ce18.jpg'])
+        )
+      )
+    ),
+    testWithLabel('asset-mixin')(
+      fs({
+        'src/feature/img.jpg': require.resolve('./assets/blank.jpg')
+      }),
+      testDefault(
+        buildDevNormal(
+          assertWebpackOk,
+          assertNoErrors,
+          assertNoMessages,
+          assertContentDev,
+          // assertSourceMapSources,
+          assertAssetUrls(['d68e763c825dc0e388929ae1b375ce18.jpg']),
+          assertAssetFiles(['d68e763c825dc0e388929ae1b375ce18.jpg'])
+        ),
+        buildDevNoUrl(
+          assertWebpackOk,
+          assertNoErrors,
+          assertNoMessages,
+          assertContentDev,
+          // assertSourcemapDev,
+          assertAssetUrls(['./feature/img.jpg']),
+          assertAssetFiles(false)
+        ),
+        buildProdNormal(
+          assertWebpackOk,
+          assertNoErrors,
+          assertNoMessages,
+          assertContentProd,
+          // assertSourceMapSources,
+          assertAssetUrls(['d68e763c825dc0e388929ae1b375ce18.jpg']),
+          assertAssetFiles(['d68e763c825dc0e388929ae1b375ce18.jpg'])
+        ),
+        buildProdNoUrl(
+          assertWebpackOk,
+          assertNoErrors,
+          assertNoMessages,
+          assertContentProd,
+          // assertSourcemapProd,
+          assertAssetUrls(['./feature/img.jpg']),
+          assertAssetFiles(false)
+        ),
+        buildProdNoDevtool(
+          assertWebpackOk,
+          assertNoErrors,
+          assertNoMessages,
+          assertContentProd,
+          assertNoSourceMap,
+          assertAssetUrls(['d68e763c825dc0e388929ae1b375ce18.jpg']),
+          assertAssetFiles(['d68e763c825dc0e388929ae1b375ce18.jpg'])
+        )
+      ),
+      testDebug(
+        buildDevNormal(
+          assertWebpackOk,
+          assertNoErrors,
+          assertMixinMessages,
+          assertContentDev,
+          // assertSourceMapSources,
+          assertAssetUrls(['d68e763c825dc0e388929ae1b375ce18.jpg']),
+          assertAssetFiles(['d68e763c825dc0e388929ae1b375ce18.jpg'])
+        ),
+        buildDevNoUrl(
+          assertWebpackOk,
+          assertNoErrors,
+          assertMixinMessages,
+          assertContentDev,
+          // assertSourcemapDev,
+          assertAssetUrls(['./feature/img.jpg']),
+          assertAssetFiles(false)
+        ),
+        buildProdNormal(
+          assertWebpackOk,
+          assertNoErrors,
+          assertMixinMessages,
+          assertContentProd,
+          // assertSourceMapSources,
+          assertAssetUrls(['d68e763c825dc0e388929ae1b375ce18.jpg']),
+          assertAssetFiles(['d68e763c825dc0e388929ae1b375ce18.jpg'])
+        ),
+        buildProdNoUrl(
+          assertWebpackOk,
+          assertNoErrors,
+          assertMixinMessages,
+          assertContentProd,
+          // assertSourcemapProd,
+          assertAssetUrls(['./feature/img.jpg']),
+          assertAssetFiles(false)
+        ),
+        buildProdNoDevtool(
+          assertWebpackOk,
+          assertNoErrors,
+          assertMixinMessages,
+          assertContentProd,
+          assertNoSourceMap,
+          assertAssetUrls(['d68e763c825dc0e388929ae1b375ce18.jpg']),
+          assertAssetFiles(['d68e763c825dc0e388929ae1b375ce18.jpg'])
+        )
+      )
+    )
+  )
+);

--- a/test/cases/declaration-variable.postcss.js
+++ b/test/cases/declaration-variable.postcss.js
@@ -1,0 +1,375 @@
+'use strict';
+
+const {join} = require('path');
+const compose = require('compose-function');
+const outdent = require('outdent');
+const {test, layer, fs, env, cwd} = require('test-my-cli');
+
+const {trim} = require('../lib/util');
+const {withCacheBase} = require('../lib/higher-order');
+const {testDefault, testDebug, testWithLabel} = require('./common/tests');
+const {buildDevNormal, buildDevNoUrl, buildProdNormal, buildProdNoUrl, buildProdNoDevtool} = require('./common/builds');
+const {moduleNotFound} = require('./common/partials');
+const {
+  assertWebpackOk, assertNoErrors, assertNoMessages, assertContent, assertNoSourceMap, assertAssetUrls,
+  assertAssetFiles, assertStdout
+} = require('../lib/assert');
+
+const assertContentDev = compose(assertContent(/;\s*}/g, ';\n}'), outdent)`
+  .some-class-name {
+    background-image: some url($0) somewhere;
+  }
+  `;
+
+const assertContentProd = compose(assertContent(), trim)`
+  .some-class-name{background-image: some${' '}url($0)${' '}somewhere}
+  `;
+
+const assertDebugPropertyMessages = assertStdout('debug')(1)`
+  ^resolve-url-loader:[^:]+:[ ]*${'img.jpg'}
+  [ ]+${'./src/value/substring'}
+  [ ]+${'./src/value'}
+  [ ]+${'./src'}
+  [ ]+FOUND$
+  `;
+
+const assertDebugValueMessages = assertStdout('debug')(1)`
+  ^resolve-url-loader:[^:]+:[ ]*${'img.jpg'}
+  [ ]+${'./src/value/substring'}
+  [ ]+${'./src/value'}
+  [ ]+FOUND$
+  `;
+
+const assertDebugSubstringMessages = assertStdout('debug')(1)`
+  ^resolve-url-loader:[^:]+:[ ]*${'img.jpg'}
+  [ ]+${'./src/value/substring'}
+  [ ]+FOUND$
+  `;
+
+module.exports = test(
+  'declaration-variable',
+  layer('declaration-variable')(
+    cwd('.'),
+    fs({
+      'package.json': withCacheBase('package.json'),
+      'webpack.config.js': withCacheBase('webpack.config.js'),
+      'node_modules': withCacheBase('node_modules'),
+      'src/index.scss': outdent`
+          @import "value/variables.scss";
+          .some-class-name {
+            background-image: $value;
+          }
+          `,
+      'src/value/variables.scss': outdent`
+          @import "substring/variables.scss";
+          $value: some $url somewhere
+          `,
+      'src/value/substring/variables.scss': outdent`
+          $url: url('img.jpg');
+          `,
+    }),
+    env({
+      ENTRY: join('src', 'index.scss')
+    }),
+    testWithLabel('asset-missing')(
+      moduleNotFound
+    ),
+    testWithLabel('asset-property')(
+      fs({
+        'src/img.jpg': require.resolve('./assets/blank.jpg')
+      }),
+      testDefault(
+        buildDevNormal(
+          assertWebpackOk,
+          assertNoErrors,
+          assertNoMessages,
+          assertContentDev,
+          // assertSourceMapSources,
+          assertAssetUrls(['d68e763c825dc0e388929ae1b375ce18.jpg']),
+          assertAssetFiles(['d68e763c825dc0e388929ae1b375ce18.jpg'])
+        ),
+        buildDevNoUrl(
+          assertWebpackOk,
+          assertNoErrors,
+          assertNoMessages,
+          assertContentDev,
+          // assertSourcemapDev,
+          assertAssetUrls(['./img.jpg']),
+          assertAssetFiles(false)
+        ),
+        buildProdNormal(
+          assertWebpackOk,
+          assertNoErrors,
+          assertNoMessages,
+          assertContentProd,
+          // assertSourceMapSources,
+          assertAssetUrls(['d68e763c825dc0e388929ae1b375ce18.jpg']),
+          assertAssetFiles(['d68e763c825dc0e388929ae1b375ce18.jpg'])
+        ),
+        buildProdNoUrl(
+          assertWebpackOk,
+          assertNoErrors,
+          assertNoMessages,
+          assertContentProd,
+          // assertSourcemapProd,
+          assertAssetUrls(['./img.jpg']),
+          assertAssetFiles(false)
+        ),
+        buildProdNoDevtool(
+          assertWebpackOk,
+          assertNoErrors,
+          assertNoMessages,
+          assertContentProd,
+          assertNoSourceMap,
+          assertAssetUrls(['d68e763c825dc0e388929ae1b375ce18.jpg']),
+          assertAssetFiles(['d68e763c825dc0e388929ae1b375ce18.jpg'])
+        )
+      ),
+      testDebug(
+        buildDevNormal(
+          assertWebpackOk,
+          assertNoErrors,
+          assertDebugPropertyMessages,
+          assertContentDev,
+          // assertSourceMapSources,
+          assertAssetUrls(['d68e763c825dc0e388929ae1b375ce18.jpg']),
+          assertAssetFiles(['d68e763c825dc0e388929ae1b375ce18.jpg'])
+        ),
+        buildDevNoUrl(
+          assertWebpackOk,
+          assertNoErrors,
+          assertDebugPropertyMessages,
+          assertContentDev,
+          // assertSourcemapDev,
+          assertAssetUrls(['./img.jpg']),
+          assertAssetFiles(false)
+        ),
+        buildProdNormal(
+          assertWebpackOk,
+          assertNoErrors,
+          assertDebugPropertyMessages,
+          assertContentProd,
+          // assertSourceMapSources,
+          assertAssetUrls(['d68e763c825dc0e388929ae1b375ce18.jpg']),
+          assertAssetFiles(['d68e763c825dc0e388929ae1b375ce18.jpg'])
+        ),
+        buildProdNoUrl(
+          assertWebpackOk,
+          assertNoErrors,
+          assertDebugPropertyMessages,
+          assertContentProd,
+          // assertSourcemapProd,
+          assertAssetUrls(['./img.jpg']),
+          assertAssetFiles(false)
+        ),
+        buildProdNoDevtool(
+          assertWebpackOk,
+          assertNoErrors,
+          assertDebugPropertyMessages,
+          assertContentProd,
+          assertNoSourceMap,
+          assertAssetUrls(['d68e763c825dc0e388929ae1b375ce18.jpg']),
+          assertAssetFiles(['d68e763c825dc0e388929ae1b375ce18.jpg'])
+        )
+      )
+    ),
+    testWithLabel('asset-value')(
+      fs({
+        'src/value/img.jpg': require.resolve('./assets/blank.jpg')
+      }),
+      testDefault(
+        buildDevNormal(
+          assertWebpackOk,
+          assertNoErrors,
+          assertNoMessages,
+          assertContentDev,
+          // assertSourceMapSources,
+          assertAssetUrls(['d68e763c825dc0e388929ae1b375ce18.jpg']),
+          assertAssetFiles(['d68e763c825dc0e388929ae1b375ce18.jpg'])
+        ),
+        buildDevNoUrl(
+          assertWebpackOk,
+          assertNoErrors,
+          assertNoMessages,
+          assertContentDev,
+          // assertSourcemapDev,
+          assertAssetUrls(['./value/img.jpg']),
+          assertAssetFiles(false)
+        ),
+        buildProdNormal(
+          assertWebpackOk,
+          assertNoErrors,
+          assertNoMessages,
+          assertContentProd,
+          // assertSourceMapSources,
+          assertAssetUrls(['d68e763c825dc0e388929ae1b375ce18.jpg']),
+          assertAssetFiles(['d68e763c825dc0e388929ae1b375ce18.jpg'])
+        ),
+        buildProdNoUrl(
+          assertWebpackOk,
+          assertNoErrors,
+          assertNoMessages,
+          assertContentProd,
+          // assertSourcemapProd,
+          assertAssetUrls(['./value/img.jpg']),
+          assertAssetFiles(false)
+        ),
+        buildProdNoDevtool(
+          assertWebpackOk,
+          assertNoErrors,
+          assertNoMessages,
+          assertContentProd,
+          assertNoSourceMap,
+          assertAssetUrls(['d68e763c825dc0e388929ae1b375ce18.jpg']),
+          assertAssetFiles(['d68e763c825dc0e388929ae1b375ce18.jpg'])
+        )
+      ),
+      testDebug(
+        buildDevNormal(
+          assertWebpackOk,
+          assertNoErrors,
+          assertDebugValueMessages,
+          assertContentDev,
+          // assertSourceMapSources,
+          assertAssetUrls(['d68e763c825dc0e388929ae1b375ce18.jpg']),
+          assertAssetFiles(['d68e763c825dc0e388929ae1b375ce18.jpg'])
+        ),
+        buildDevNoUrl(
+          assertWebpackOk,
+          assertNoErrors,
+          assertDebugValueMessages,
+          assertContentDev,
+          // assertSourcemapDev,
+          assertAssetUrls(['./value/img.jpg']),
+          assertAssetFiles(false)
+        ),
+        buildProdNormal(
+          assertWebpackOk,
+          assertNoErrors,
+          assertDebugValueMessages,
+          assertContentProd,
+          // assertSourceMapSources,
+          assertAssetUrls(['d68e763c825dc0e388929ae1b375ce18.jpg']),
+          assertAssetFiles(['d68e763c825dc0e388929ae1b375ce18.jpg'])
+        ),
+        buildProdNoUrl(
+          assertWebpackOk,
+          assertNoErrors,
+          assertDebugValueMessages,
+          assertContentProd,
+          // assertSourcemapProd,
+          assertAssetUrls(['./value/img.jpg']),
+          assertAssetFiles(false)
+        ),
+        buildProdNoDevtool(
+          assertWebpackOk,
+          assertNoErrors,
+          assertDebugValueMessages,
+          assertContentProd,
+          assertNoSourceMap,
+          assertAssetUrls(['d68e763c825dc0e388929ae1b375ce18.jpg']),
+          assertAssetFiles(['d68e763c825dc0e388929ae1b375ce18.jpg'])
+        )
+      )
+    ),
+    testWithLabel('asset-value-substring')(
+      fs({
+        'src/value/substring/img.jpg': require.resolve('./assets/blank.jpg')
+      }),
+      testDefault(
+        buildDevNormal(
+          assertWebpackOk,
+          assertNoErrors,
+          assertNoMessages,
+          assertContentDev,
+          // assertSourceMapSources,
+          assertAssetUrls(['d68e763c825dc0e388929ae1b375ce18.jpg']),
+          assertAssetFiles(['d68e763c825dc0e388929ae1b375ce18.jpg'])
+        ),
+        buildDevNoUrl(
+          assertWebpackOk,
+          assertNoErrors,
+          assertNoMessages,
+          assertContentDev,
+          // assertSourcemapDev,
+          assertAssetUrls(['./value/substring/img.jpg']),
+          assertAssetFiles(false)
+        ),
+        buildProdNormal(
+          assertWebpackOk,
+          assertNoErrors,
+          assertNoMessages,
+          assertContentProd,
+          // assertSourceMapSources,
+          assertAssetUrls(['d68e763c825dc0e388929ae1b375ce18.jpg']),
+          assertAssetFiles(['d68e763c825dc0e388929ae1b375ce18.jpg'])
+        ),
+        buildProdNoUrl(
+          assertWebpackOk,
+          assertNoErrors,
+          assertNoMessages,
+          assertContentProd,
+          // assertSourcemapProd,
+          assertAssetUrls(['./value/substring/img.jpg']),
+          assertAssetFiles(false)
+        ),
+        buildProdNoDevtool(
+          assertWebpackOk,
+          assertNoErrors,
+          assertNoMessages,
+          assertContentProd,
+          assertNoSourceMap,
+          assertAssetUrls(['d68e763c825dc0e388929ae1b375ce18.jpg']),
+          assertAssetFiles(['d68e763c825dc0e388929ae1b375ce18.jpg'])
+        )
+      ),
+      testDebug(
+        buildDevNormal(
+          assertWebpackOk,
+          assertNoErrors,
+          assertDebugSubstringMessages,
+          assertContentDev,
+          // assertSourceMapSources,
+          assertAssetUrls(['d68e763c825dc0e388929ae1b375ce18.jpg']),
+          assertAssetFiles(['d68e763c825dc0e388929ae1b375ce18.jpg'])
+        ),
+        buildDevNoUrl(
+          assertWebpackOk,
+          assertNoErrors,
+          assertDebugSubstringMessages,
+          assertContentDev,
+          // assertSourcemapDev,
+          assertAssetUrls(['./value/substring/img.jpg']),
+          assertAssetFiles(false)
+        ),
+        buildProdNormal(
+          assertWebpackOk,
+          assertNoErrors,
+          assertDebugSubstringMessages,
+          assertContentProd,
+          // assertSourceMapSources,
+          assertAssetUrls(['d68e763c825dc0e388929ae1b375ce18.jpg']),
+          assertAssetFiles(['d68e763c825dc0e388929ae1b375ce18.jpg'])
+        ),
+        buildProdNoUrl(
+          assertWebpackOk,
+          assertNoErrors,
+          assertDebugSubstringMessages,
+          assertContentProd,
+          // assertSourcemapProd,
+          assertAssetUrls(['./value/substring/img.jpg']),
+          assertAssetFiles(false)
+        ),
+        buildProdNoDevtool(
+          assertWebpackOk,
+          assertNoErrors,
+          assertDebugSubstringMessages,
+          assertContentProd,
+          assertNoSourceMap,
+          assertAssetUrls(['d68e763c825dc0e388929ae1b375ce18.jpg']),
+          assertAssetFiles(['d68e763c825dc0e388929ae1b375ce18.jpg'])
+        )
+      )
+    )
+  )
+);

--- a/test/cases/deep-asset.js
+++ b/test/cases/deep-asset.js
@@ -102,7 +102,7 @@ const assertSourcemapProd = sequence(
         return outdent`
           /src/feature/index.scss
             1:1
-            2:3->1:64 2:3->1:18
+            2:3->1:18 2:3->1:64
             3:3->1:64 3:3->1:110
             4:3->1:110 4:3->1:149
             5:3->1:149 5:3->1:185

--- a/test/cases/http-asset.js
+++ b/test/cases/http-asset.js
@@ -101,7 +101,7 @@ const assertSourcemapProd = sequence(
         return outdent`
           /src/feature/index.scss
             1:1
-            2:3->1:57 2:3->1:18
+            2:3->1:18 2:3->1:57
             3:3->1:57 3:3->1:96
             4:3->1:96 4:3->1:128
             5:3->1:128 5:3->1:163

--- a/test/cases/immediate-asset.js
+++ b/test/cases/immediate-asset.js
@@ -102,7 +102,7 @@ const assertSourcemapProd = sequence(
         return outdent`
           /src/feature/index.scss
             1:1
-            2:3->1:57 2:3->1:18
+            2:3->1:18 2:3->1:57
             3:3->1:57 3:3->1:96
             4:3->1:96 4:3->1:128
             5:3->1:128 5:3->1:157

--- a/test/cases/module-relative-asset.js
+++ b/test/cases/module-relative-asset.js
@@ -102,7 +102,7 @@ const assertSourcemapProd = sequence(
         return outdent`
           /src/feature/index.scss
             1:1
-            2:3->1:55 2:3->1:18
+            2:3->1:18 2:3->1:55
             3:3->1:55 3:3->1:92
             4:3->1:92 4:3->1:122
             5:3->1:122 5:3->1:155

--- a/test/cases/nested-import-mixed-quotes.js
+++ b/test/cases/nested-import-mixed-quotes.js
@@ -29,10 +29,10 @@ const assertSourcemapDev = sequence(
         return outdent`
           /src/feature/index.scss
             1:1
-            2:3
+            3:2
           
           /src/index.scss
-            3:2
+            2:3
           `;
       case (engine === 'postcss'):
         return outdent`
@@ -48,7 +48,7 @@ const assertSourcemapDev = sequence(
   })
 );
 
-const assertSourceMapSourcesDev = assertSourceMapContent([
+const assertSourceMapSources = assertSourceMapContent([
   '/src/feature/index.scss',
   '/src/index.scss'
 ]);
@@ -72,16 +72,18 @@ const assertSourcemapProd = sequence(
         return outdent`
           /src/feature/index.scss
             1:1
+          
+          /src/index.scss
             2:3->1:38
           `;
       case (engine === 'rework') && (webpack === 4):
         return outdent`
           /src/feature/index.scss
             1:1
-            2:3->1:38 2:3->1:282
+            3:2->1:283
           
           /src/index.scss
-            3:2->1:283
+            2:3->1:38 2:3->1:282
           `;
       case (engine === 'postcss') && (webpack < 4):
         return outdent`
@@ -104,21 +106,6 @@ const assertSourcemapProd = sequence(
     }
   })
 );
-
-const assertSourceMapSourcesProd = assertSourceMapContent(({meta: {engine, version: {webpack}}}) => {
-  switch (true) {
-    case (engine === 'rework') && (webpack < 4):
-      // known issue with reworkcss dropping sourcemap sources (#52)
-      return [
-        '/src/feature/index.scss',
-      ];
-    default:
-      return [
-        '/src/feature/index.scss',
-        '/src/index.scss'
-      ];
-  }
-});
 
 const assertAssets = sequence(
   assertAssetUrls([
@@ -163,7 +150,7 @@ module.exports = test(
         assertNoErrors,
         assertNoMessages,
         assertContentDev,
-        assertSourceMapSourcesDev,
+        assertSourceMapSources,
         assertAssets
       ),
       buildDevNoUrl(
@@ -179,7 +166,7 @@ module.exports = test(
         assertNoErrors,
         assertNoMessages,
         assertContentProd,
-        assertSourceMapSourcesProd,
+        assertSourceMapSources,
         assertAssets
       ),
       buildProdNoUrl(
@@ -205,7 +192,7 @@ module.exports = test(
         assertNoErrors,
         assertNoMessages,
         assertContentDev,
-        assertSourceMapSourcesDev,
+        assertSourceMapSources,
         assertAssets
       ),
       buildDevNoUrl(
@@ -213,7 +200,7 @@ module.exports = test(
         assertNoErrors,
         assertNoMessages,
         assertContentDev,
-        assertSourceMapSourcesDev,
+        assertSourceMapSources,
         assertAssets
       ),
       buildProdNormal(
@@ -221,7 +208,7 @@ module.exports = test(
         assertNoErrors,
         assertNoMessages,
         assertContentProd,
-        assertSourceMapSourcesProd,
+        assertSourceMapSources,
         assertAssets
       ),
       buildProdNoUrl(
@@ -229,7 +216,7 @@ module.exports = test(
         assertNoErrors,
         assertNoMessages,
         assertContentProd,
-        assertSourceMapSourcesProd,
+        assertSourceMapSources,
         assertAssets
       ),
       buildProdNoDevtool(
@@ -247,7 +234,7 @@ module.exports = test(
         assertNoErrors,
         assertNoMessages,
         assertContentDev,
-        assertSourceMapSourcesDev,
+        assertSourceMapSources,
         assertAssets
       ),
       buildDevNoUrl(
@@ -255,7 +242,7 @@ module.exports = test(
         assertNoErrors,
         assertNoMessages,
         assertContentDev,
-        assertSourceMapSourcesDev,
+        assertSourceMapSources,
         assertAssets
       ),
       buildProdNormal(
@@ -263,7 +250,7 @@ module.exports = test(
         assertNoErrors,
         assertNoMessages,
         assertContentProd,
-        assertSourceMapSourcesProd,
+        assertSourceMapSources,
         assertAssets
       ),
       buildProdNoUrl(
@@ -271,7 +258,7 @@ module.exports = test(
         assertNoErrors,
         assertNoMessages,
         assertContentProd,
-        assertSourceMapSourcesProd,
+        assertSourceMapSources,
         assertAssets
       ),
       buildProdNoDevtool(
@@ -289,7 +276,7 @@ module.exports = test(
         assertNoErrors,
         assertNoMessages,
         assertContentDev,
-        assertSourceMapSourcesDev,
+        assertSourceMapSources,
         assertAssets
       ),
       buildDevNoUrl(
@@ -297,7 +284,7 @@ module.exports = test(
         assertNoErrors,
         assertNoMessages,
         assertContentDev,
-        assertSourceMapSourcesDev,
+        assertSourceMapSources,
         assertAssets
       ),
       buildProdNormal(
@@ -305,7 +292,7 @@ module.exports = test(
         assertNoErrors,
         assertNoMessages,
         assertContentProd,
-        assertSourceMapSourcesProd,
+        assertSourceMapSources,
         assertAssets
       ),
       buildProdNoUrl(
@@ -313,7 +300,7 @@ module.exports = test(
         assertNoErrors,
         assertNoMessages,
         assertContentProd,
-        assertSourceMapSourcesProd,
+        assertSourceMapSources,
         assertAssets
       ),
       buildProdNoDevtool(

--- a/test/cases/orphan-carriage-return.postcss.js
+++ b/test/cases/orphan-carriage-return.postcss.js
@@ -34,8 +34,11 @@ module.exports = test(
       'src/index.scss': outdent`
         .some-class-name {
           font-size: calc(${'\r'}
-            (1px)${'\r'}
+            (${'\r'}1px${'\r'})${'\r'}
           );
+        }
+        
+        .another-class-name {
           background-image: url('img.jpg');
         }
         `,

--- a/test/cases/orphan-carriage-return.postcss.js
+++ b/test/cases/orphan-carriage-return.postcss.js
@@ -30,14 +30,16 @@ module.exports = test(
       'package.json': withCacheBase('package.json'),
       'webpack.config.js': withCacheBase('webpack.config.js'),
       'node_modules': withCacheBase('node_modules'),
+      // NOTE - the CR in the calc() statement induce an offset before the url() statement is hit
       'src/index.scss': outdent`
         .some-class-name {
           font-size: calc(${'\r'}
             (1px)${'\r'}
           );
-          background-image: url(data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==);
+          background-image: url('img.jpg');
         }
-        `
+        `,
+      'src/img.jpg': require.resolve('./assets/blank.jpg'),
     }),
     env({
       ENTRY: join('src', 'index.scss')

--- a/test/cases/root-relative-asset.js
+++ b/test/cases/root-relative-asset.js
@@ -102,7 +102,7 @@ const assertSourcemapProd = sequence(
         return outdent`
           /src/feature/index.scss
             1:1
-            2:3->1:57 2:3->1:18
+            2:3->1:18 2:3->1:57
             3:3->1:57 3:3->1:96
             4:3->1:96 4:3->1:128
             5:3->1:128 5:3->1:157

--- a/test/cases/shallow-asset.js
+++ b/test/cases/shallow-asset.js
@@ -102,7 +102,7 @@ const assertSourcemapProd = sequence(
         return outdent`
           /src/feature/index.scss
             1:1
-            2:3->1:56 2:3->1:18
+            2:3->1:18 2:3->1:56
             3:3->1:56 3:3->1:94
             4:3->1:94 4:3->1:125
             5:3->1:125 5:3->1:153

--- a/test/lib/assert.js
+++ b/test/lib/assert.js
@@ -145,7 +145,7 @@ exports.assertSourceMapContent = (fieldOrExpected) => sequence(
             'should yield expected source-map mappings'
           );
         } else {
-          throw new Error('expectation must be String|Array.<String>');
+          throw new Error('expectation must be String|String[]');
         }
       } else {
         pass('should NOT expect source-map sources');

--- a/test/lib/higher-order.js
+++ b/test/lib/higher-order.js
@@ -24,8 +24,9 @@ exports.withCacheBase = withBase(({meta: {cacheDir}}) => cacheDir);
 /**
  * A factory for a higher-order-function that wraps a function of RegExp with template literal.
  *
- * @param {Array.<string>} strings Template literal strings
- * @param {...*} substitutions Any number of template literal substitutions
+ * @param {function} next The function to call with the pattern regex
+ * @param {string[]} strings Template literal strings
+ * @param {...*} Any number of template literal substitutions
  * @return {function(function)} A higher-order-function of the assert function
  */
 exports.withPattern = (next) => (strings, ...substitutions) => {

--- a/test/lib/sourcemap.js
+++ b/test/lib/sourcemap.js
@@ -81,7 +81,13 @@ exports.absoluteToString = (absolute) => {
     .map((filename, i) => {
       const linesHash = elements
         .filter(({file}) => file === i)
-        .sort(({from: [la, ca]}, {from: [lb, cb]}) => (la - lb) || (ca - cb))
+        .sort(
+          ({from: [l1, c1], to: [l3, c3]}, {from: [l2, c2], to: [l4, c4]}) =>
+            (l1 - l2) ||
+            (c1 - c2) ||
+            (l3 - l4) ||
+            (c3 - c4)
+        )
         .reduce((r, el) => {
           const [fromLine] = el.from;
           const list = (r[fromLine] || []).concat(el);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,6 +5,7 @@
 adjust-sourcemap-loader@2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/adjust-sourcemap-loader/-/adjust-sourcemap-loader-2.0.0.tgz#6471143af75ec02334b219f54bc7970c52fb29a4"
+  integrity sha512-4hFsTsn58+YjrU9qKzML2JSSDqKvN8mUGQ0nNIrfPi8hmIONT4L3uUaT6MKdMsZ9AjsU6D2xDkZxCkbQPxChrA==
   dependencies:
     assert "1.4.1"
     camelcase "5.0.0"
@@ -12,71 +13,81 @@ adjust-sourcemap-loader@2.0.0:
     object-path "0.11.4"
     regex-parser "2.2.10"
 
-amdefine@>=0.0.4:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
-
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
+  integrity sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
 
 ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
+  integrity sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=
 
 ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
+  integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
   dependencies:
     color-convert "^1.9.0"
 
 argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
+  integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
 
 arity-n@^1.0.4:
   version "1.0.4"
   resolved "https://registry.npmjs.org/arity-n/-/arity-n-1.0.4.tgz#d9e76b11733e08569c0847ae7b39b2860b30b745"
+  integrity sha1-2edrEXM+CFacCEeuezmyhgswt0U=
 
 arr-diff@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
+  integrity sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=
 
 arr-flatten@^1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz#36048bbff4e7b47e136644316c99669ea5ae91f1"
+  integrity sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==
 
 arr-union@^3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
+  integrity sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=
 
 array-unique@^0.3.2:
   version "0.3.2"
   resolved "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
+  integrity sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=
 
 assert@1.4.1:
   version "1.4.1"
   resolved "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz#99912d591836b5a6f5b345c0f07eefc08fc65d91"
+  integrity sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=
   dependencies:
     util "0.10.3"
 
 assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
+  integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
 
 atob@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz#ae2d5a729477f289d60dd7f96a6314a22dd6c22a"
+  version "2.1.2"
+  resolved "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
+  integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
+  integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
 base@^0.11.1:
   version "0.11.2"
   resolved "https://registry.npmjs.org/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f"
+  integrity sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==
   dependencies:
     cache-base "^1.0.1"
     class-utils "^0.3.5"
@@ -89,16 +100,19 @@ base@^0.11.1:
 big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
+  integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
 
 blue-tape@1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/blue-tape/-/blue-tape-1.0.0.tgz#7581d04c07395c95c426b2ed6d1edb454a76b92b"
+  integrity sha1-dYHQTAc5XJXEJrLtbR7bRUp2uSs=
   dependencies:
     tape ">=2.0.0 <5.0.0"
 
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
+  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
@@ -106,6 +120,7 @@ brace-expansion@^1.1.7:
 braces@^2.3.1:
   version "2.3.2"
   resolved "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz#5979fd3f14cd531565e5fa2df1abfff1dfaee729"
+  integrity sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==
   dependencies:
     arr-flatten "^1.1.0"
     array-unique "^0.3.2"
@@ -121,6 +136,7 @@ braces@^2.3.1:
 cache-base@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz#0a7f46416831c8b662ee36fe4e7c59d76f666ab2"
+  integrity sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==
   dependencies:
     collection-visit "^1.0.0"
     component-emitter "^1.2.1"
@@ -135,8 +151,9 @@ cache-base@^1.0.1:
 camelcase@5.0.0:
   version "5.0.0"
   resolved "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz#03295527d58bd3cd4aa75363f35b2e8d97be2f42"
+  integrity sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==
 
-"camelcase@5.3.1 ":
+camelcase@5.3.1:
   version "5.3.1"
   resolved "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
@@ -144,6 +161,7 @@ camelcase@5.0.0:
 chalk@^1.1.1:
   version "1.1.3"
   resolved "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
+  integrity sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=
   dependencies:
     ansi-styles "^2.2.1"
     escape-string-regexp "^1.0.2"
@@ -154,6 +172,7 @@ chalk@^1.1.1:
 chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
+  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
   dependencies:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
@@ -162,6 +181,7 @@ chalk@^2.4.2:
 class-utils@^0.3.5:
   version "0.3.6"
   resolved "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz#f93369ae8b9a7ce02fd41faad0ca83033190c463"
+  integrity sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==
   dependencies:
     arr-union "^3.1.0"
     define-property "^0.2.5"
@@ -171,6 +191,7 @@ class-utils@^0.3.5:
 cli@~1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz#22817534f24bfa4950c34d532d48ecbc621b8c14"
+  integrity sha1-IoF1NPJL+klQw01TLUjsvGIbjBQ=
   dependencies:
     exit "0.1.2"
     glob "^7.1.1"
@@ -178,57 +199,68 @@ cli@~1.0.0:
 collection-visit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz#4bc0373c164bc3291b4d368c829cf1a80a59dca0"
+  integrity sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=
   dependencies:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
 
 color-convert@^1.9.0:
-  version "1.9.2"
-  resolved "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz#49881b8fba67df12a96bdf3f56c0aab9e7913147"
+  version "1.9.3"
+  resolved "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
+  integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
   dependencies:
-    color-name "1.1.1"
+    color-name "1.1.3"
 
-color-name@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz#4b1415304cf50028ea81643643bd82ea05803689"
+color-name@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
+  integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
 component-emitter@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
+  integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
 
 compose-function@3.0.3:
   version "3.0.3"
   resolved "https://registry.npmjs.org/compose-function/-/compose-function-3.0.3.tgz#9ed675f13cc54501d30950a486ff6a7ba3ab185f"
+  integrity sha1-ntZ18TzFRQHTCVCkhv9qe6OrGF8=
   dependencies:
     arity-n "^1.0.4"
 
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+  integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
 console-browserify@1.1.x:
   version "1.1.0"
   resolved "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz#f0241c45730a9fc6323b206dbf38edc741d0bb10"
+  integrity sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=
   dependencies:
     date-now "^0.1.4"
 
 convert-source-map@1.6.0:
   version "1.6.0"
   resolved "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz#51b537a8c43e0f04dec1993bffcdd504e758ac20"
+  integrity sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==
   dependencies:
     safe-buffer "~5.1.1"
 
 convert-source-map@^0.3.3:
   version "0.3.5"
   resolved "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz#f1d802950af7dd2631a1febe0596550c86ab3190"
+  integrity sha1-8dgClQr33SYxof6+BZZVDIarMZA=
 
 copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
+  integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
 core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+  integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
 cross-env@5.2.1:
   version "5.2.1"
@@ -240,6 +272,7 @@ cross-env@5.2.1:
 cross-spawn@6.0.5, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
+  integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
   dependencies:
     nice-try "^1.0.4"
     path-key "^2.0.1"
@@ -248,66 +281,70 @@ cross-spawn@6.0.5, cross-spawn@^6.0.5:
     which "^1.2.9"
 
 css@^2.0.0:
-  version "2.2.3"
-  resolved "https://registry.npmjs.org/css/-/css-2.2.3.tgz#f861f4ba61e79bedc962aa548e5780fd95cbc6be"
+  version "2.2.4"
+  resolved "https://registry.npmjs.org/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
+  integrity sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==
   dependencies:
-    inherits "^2.0.1"
-    source-map "^0.1.38"
-    source-map-resolve "^0.5.1"
+    inherits "^2.0.3"
+    source-map "^0.6.1"
+    source-map-resolve "^0.5.2"
     urix "^0.1.0"
 
-d@1:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/d/-/d-1.0.0.tgz#754bb5bfe55451da69a58b94d45f4c5b0462d58f"
+d@1, d@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/d/-/d-1.0.1.tgz#8698095372d58dbee346ffd0c7093f99f8f9eb5a"
+  integrity sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==
   dependencies:
-    es5-ext "^0.10.9"
+    es5-ext "^0.10.50"
+    type "^1.0.1"
 
 date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
+  integrity sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=
 
 debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
   resolved "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   dependencies:
     ms "2.0.0"
 
 decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
+  integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
 
 deep-equal@~1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
+  integrity sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=
 
-define-properties@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz#83a73f2fea569898fb737193c8f873caf6d45c94"
-  dependencies:
-    foreach "^2.0.5"
-    object-keys "^1.0.8"
-
-define-properties@^1.1.3:
+define-properties@^1.1.2, define-properties@^1.1.3:
   version "1.1.3"
   resolved "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
+  integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
   dependencies:
     object-keys "^1.0.12"
 
 define-property@^0.2.5:
   version "0.2.5"
   resolved "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz#c35b1ef918ec3c990f9a5bc57be04aacec5c8116"
+  integrity sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=
   dependencies:
     is-descriptor "^0.1.0"
 
 define-property@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz#769ebaaf3f4a63aad3af9e8d304c9bbe79bfb0e6"
+  integrity sha1-dp66rz9KY6rTr56NMEybvnm/sOY=
   dependencies:
     is-descriptor "^1.0.0"
 
 define-property@^2.0.2:
   version "2.0.2"
   resolved "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz#d459689e8d654ba77e02a817f8710d702cb16e9d"
+  integrity sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==
   dependencies:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
@@ -315,35 +352,42 @@ define-property@^2.0.2:
 defined@~1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693"
+  integrity sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=
 
 diff@^2.2.1:
   version "2.2.3"
   resolved "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz#60eafd0d28ee906e4e8ff0a52c1229521033bf99"
+  integrity sha1-YOr9DSjukG5Oj/ClLBIpUhAzv5k=
 
 dom-serializer@0:
-  version "0.1.0"
-  resolved "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
+  version "0.2.1"
+  resolved "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.1.tgz#13650c850daffea35d8b626a4cfc4d3a17643fdb"
+  integrity sha512-sK3ujri04WyjwQXVoK4PU3y8ula1stq10GJZpqHIUgoGZdsGzAGu65BnU3d08aTVSvO7mGPZUc0wTEDL+qGE0Q==
   dependencies:
-    domelementtype "~1.1.1"
-    entities "~1.1.1"
+    domelementtype "^2.0.1"
+    entities "^2.0.0"
 
 domelementtype@1:
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz#b17aed82e8ab59e52dd9c19b1756e0fc187204c2"
+  version "1.3.1"
+  resolved "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz#d048c44b37b0d10a7f2a3d5fee3f4333d790481f"
+  integrity sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==
 
-domelementtype@~1.1.1:
-  version "1.1.3"
-  resolved "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz#bd28773e2642881aec51544924299c5cd822185b"
+domelementtype@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz#1f8bdfe91f5a78063274e803b4bdcedf6e94f94d"
+  integrity sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==
 
 domhandler@2.3:
   version "2.3.0"
   resolved "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz#2de59a0822d5027fabff6f032c2b25a2a8abe738"
+  integrity sha1-LeWaCCLVAn+r/28DLCsloqir5zg=
   dependencies:
     domelementtype "1"
 
 domutils@1.5:
   version "1.5.1"
   resolved "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
+  integrity sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=
   dependencies:
     dom-serializer "0"
     domelementtype "1"
@@ -351,67 +395,61 @@ domutils@1.5:
 duplexer@^0.1.1:
   version "0.1.1"
   resolved "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
+  integrity sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=
 
 emojis-list@^2.0.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
+  integrity sha1-TapNnbAPmBmIDHn6RXrlsJof04k=
 
 entities@1.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz#b2987aa3821347fcde642b24fdfc9e4fb712bf26"
+  integrity sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=
 
-entities@~1.1.1:
-  version "1.1.1"
-  resolved "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
+entities@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz#68d6084cab1b079767540d80e56a39b423e4abf4"
+  integrity sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==
 
-es-abstract@^1.12.0:
-  version "1.13.0"
-  resolved "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz#ac86145fdd5099d8dd49558ccba2eaf9b88e24e9"
+es-abstract@^1.12.0, es-abstract@^1.4.3, es-abstract@^1.5.0:
+  version "1.14.2"
+  resolved "https://registry.npmjs.org/es-abstract/-/es-abstract-1.14.2.tgz#7ce108fad83068c8783c3cdf62e504e084d8c497"
+  integrity sha512-DgoQmbpFNOofkjJtKwr87Ma5EW4Dc8fWhD0R+ndq7Oc456ivUfGOOP6oAZTTKl5/CcNMP+EN+e3/iUzgE0veZg==
   dependencies:
     es-to-primitive "^1.2.0"
     function-bind "^1.1.1"
     has "^1.0.3"
+    has-symbols "^1.0.0"
     is-callable "^1.1.4"
     is-regex "^1.0.4"
-    object-keys "^1.0.12"
-
-es-abstract@^1.4.3, es-abstract@^1.5.0:
-  version "1.11.0"
-  resolved "https://registry.npmjs.org/es-abstract/-/es-abstract-1.11.0.tgz#cce87d518f0496893b1a30cd8461835535480681"
-  dependencies:
-    es-to-primitive "^1.1.1"
-    function-bind "^1.1.1"
-    has "^1.0.1"
-    is-callable "^1.1.3"
-    is-regex "^1.0.4"
-
-es-to-primitive@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz#45355248a88979034b6792e19bb81f2b7975dd0d"
-  dependencies:
-    is-callable "^1.1.1"
-    is-date-object "^1.0.1"
-    is-symbol "^1.0.1"
+    object-inspect "^1.6.0"
+    object-keys "^1.1.1"
+    string.prototype.trimleft "^2.0.0"
+    string.prototype.trimright "^2.0.0"
 
 es-to-primitive@^1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz#edf72478033456e8dda8ef09e00ad9650707f377"
+  integrity sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==
   dependencies:
     is-callable "^1.1.4"
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-es5-ext@^0.10.35, es5-ext@^0.10.9, es5-ext@~0.10.14:
-  version "0.10.46"
-  resolved "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.46.tgz#efd99f67c5a7ec789baa3daa7f79870388f7f572"
+es5-ext@^0.10.35, es5-ext@^0.10.50, es5-ext@^0.10.51:
+  version "0.10.51"
+  resolved "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.51.tgz#ed2d7d9d48a12df86e0299287e93a09ff478842f"
+  integrity sha512-oRpWzM2WcLHVKpnrcyB7OW8j/s67Ba04JCm0WnNv3RiABSvs7mrQlutB8DBv793gKcp0XENR8Il8WxGTlZ73gQ==
   dependencies:
     es6-iterator "~2.0.3"
     es6-symbol "~3.1.1"
-    next-tick "1"
+    next-tick "^1.0.0"
 
 es6-iterator@2.0.3, es6-iterator@~2.0.3:
   version "2.0.3"
   resolved "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
+  integrity sha1-p96IkUGgWpSwhUQDstCg+/qY87c=
   dependencies:
     d "1"
     es5-ext "^0.10.35"
@@ -423,31 +461,37 @@ es6-promisify@6.0.2:
   integrity sha512-eO6vFm0JvqGzjWIQA6QVKjxpmELfhWbDUWHm1rPfIbn55mhKPiAa5xpLmQWJrNa629ZIeQ8ZvMAi13kvrjK6Mg==
 
 es6-symbol@^3.1.1, es6-symbol@~3.1.1:
-  version "3.1.1"
-  resolved "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz#bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77"
+  version "3.1.2"
+  resolved "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.2.tgz#859fdd34f32e905ff06d752e7171ddd4444a7ed1"
+  integrity sha512-/ZypxQsArlv+KHpGvng52/Iz8by3EQPxhmbuz8yFG89N/caTFBSbcXONDw0aMjy827gQg26XAjP4uXFvnfINmQ==
   dependencies:
-    d "1"
-    es5-ext "~0.10.14"
+    d "^1.0.1"
+    es5-ext "^0.10.51"
 
 escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
+  integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
 esprima@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
+  version "4.0.1"
+  resolved "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
+  integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
 events-to-array@^1.0.1:
   version "1.1.2"
   resolved "https://registry.npmjs.org/events-to-array/-/events-to-array-1.1.2.tgz#2d41f563e1fe400ed4962fe1a4d5c6a7539df7f6"
+  integrity sha1-LUH1Y+H+QA7Uli/hpNXGp1Od9/Y=
 
 exit@0.1.2, exit@0.1.x:
   version "0.1.2"
   resolved "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
+  integrity sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=
 
 expand-brackets@^2.1.4:
   version "2.1.4"
   resolved "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz#b77735e315ce30f6b6eff0f83b04151a22449622"
+  integrity sha1-t3c14xXOMPa27/D4OwQVGiJEliI=
   dependencies:
     debug "^2.3.3"
     define-property "^0.2.5"
@@ -460,12 +504,14 @@ expand-brackets@^2.1.4:
 extend-shallow@^2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
+  integrity sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=
   dependencies:
     is-extendable "^0.1.0"
 
 extend-shallow@^3.0.0, extend-shallow@^3.0.2:
   version "3.0.2"
   resolved "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz#26a71aaf073b39fb2127172746131c2704028db8"
+  integrity sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=
   dependencies:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
@@ -473,6 +519,7 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
 extglob@^2.0.4:
   version "2.0.4"
   resolved "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz#ad00fe4dc612a9232e8718711dc5cb5ab0285543"
+  integrity sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==
   dependencies:
     array-unique "^0.3.2"
     define-property "^1.0.0"
@@ -486,6 +533,7 @@ extglob@^2.0.4:
 figures@^1.4.0:
   version "1.7.0"
   resolved "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
+  integrity sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=
   dependencies:
     escape-string-regexp "^1.0.5"
     object-assign "^4.1.0"
@@ -493,64 +541,58 @@ figures@^1.4.0:
 fill-range@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz#d544811d428f98eb06a63dc402d2403c328c38f7"
+  integrity sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=
   dependencies:
     extend-shallow "^2.0.1"
     is-number "^3.0.0"
     repeat-string "^1.6.1"
     to-regex-range "^2.1.0"
 
-for-each@~0.3.2:
-  version "0.3.2"
-  resolved "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz#2c40450b9348e97f281322593ba96704b9abd4d4"
+for-each@~0.3.3:
+  version "0.3.3"
+  resolved "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
+  integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
   dependencies:
-    is-function "~1.0.0"
+    is-callable "^1.1.3"
 
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
-
-foreach@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
+  integrity sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=
 
 fragment-cache@^0.2.1:
   version "0.2.1"
   resolved "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz#4290fad27f13e89be7f33799c6bc5a0abfff0d19"
+  integrity sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=
   dependencies:
     map-cache "^0.2.2"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+  integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
 function-bind@^1.0.2, function-bind@^1.1.1, function-bind@~1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
+  integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
 get-value@3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/get-value/-/get-value-3.0.1.tgz#5efd2a157f1d6a516d7524e124ac52d0a39ef5a8"
+  integrity sha512-mKZj9JLQrwMBtj5wxi6MH8Z5eSKaERpAwjg43dPtlGI1ZVEgH/qC7T8/6R2OBSUA+zzHBZgICsVJaEIV2tKTDA==
   dependencies:
     isobject "^3.0.1"
 
 get-value@^2.0.2, get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
   resolved "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
+  integrity sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=
 
-glob@^7.1.1, glob@~7.1.2:
-  version "7.1.2"
-  resolved "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.4"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@^7.1.3:
-  version "7.1.3"
-  resolved "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
+glob@^7.1.1, glob@^7.1.3, glob@~7.1.4:
+  version "7.1.4"
+  resolved "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
+  integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -562,26 +604,31 @@ glob@^7.1.3:
 has-ansi@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
+  integrity sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=
   dependencies:
     ansi-regex "^2.0.0"
 
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+  integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
 
 has-prop@0.1.2:
   version "0.1.2"
   resolved "https://registry.npmjs.org/has-prop/-/has-prop-0.1.2.tgz#676f88c335a8264141cf75ce88a6b6c522b62bea"
+  integrity sha1-Z2+IwzWoJkFBz3XOiKa2xSK2K+o=
   dependencies:
     get-value "^2.0.2"
 
 has-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
+  integrity sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=
 
 has-value@^0.3.1:
   version "0.3.1"
   resolved "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz#7b1f58bada62ca827ec0a2078025654845995e1f"
+  integrity sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=
   dependencies:
     get-value "^2.0.3"
     has-values "^0.1.4"
@@ -590,6 +637,7 @@ has-value@^0.3.1:
 has-value@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz#18b281da585b1c5c51def24c930ed29a0be6b177"
+  integrity sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=
   dependencies:
     get-value "^2.0.6"
     has-values "^1.0.0"
@@ -598,23 +646,20 @@ has-value@^1.0.0:
 has-values@^0.1.4:
   version "0.1.4"
   resolved "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz#6d61de95d91dfca9b9a02089ad384bff8f62b771"
+  integrity sha1-bWHeldkd/Km5oCCJrThL/49it3E=
 
 has-values@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz#95b0b63fec2146619a6fe57fe75628d5a39efe4f"
+  integrity sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=
   dependencies:
     is-number "^3.0.0"
     kind-of "^4.0.0"
 
-has@^1.0.1, has@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/has/-/has-1.0.1.tgz#8461733f538b0837c9361e39a9ab9e9704dc2f28"
-  dependencies:
-    function-bind "^1.0.2"
-
-has@^1.0.3:
+has@^1.0.1, has@^1.0.3, has@~1.0.3:
   version "1.0.3"
   resolved "https://registry.npmjs.org/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
+  integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
   dependencies:
     function-bind "^1.1.1"
 
@@ -626,6 +671,7 @@ hoek@6.x.x:
 htmlparser2@3.8.x:
   version "3.8.3"
   resolved "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz#996c28b191516a8be86501a7d79757e5c70c1068"
+  integrity sha1-mWwosZFRaovoZQGn15dX5ccMEGg=
   dependencies:
     domelementtype "1"
     domhandler "2.3"
@@ -636,61 +682,68 @@ htmlparser2@3.8.x:
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
+  integrity sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=
   dependencies:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.1, inherits@~2.0.1, inherits@~2.0.3:
-  version "2.0.3"
-  resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+inherits@2, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3, inherits@~2.0.4:
+  version "2.0.4"
+  resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
+  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
 inherits@2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
+  integrity sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=
 
 is-accessor-descriptor@^0.1.6:
   version "0.1.6"
   resolved "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz#a9e12cb3ae8d876727eeef3843f8a0897b5c98d6"
+  integrity sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=
   dependencies:
     kind-of "^3.0.2"
 
 is-accessor-descriptor@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz#169c2f6d3df1f992618072365c9b0ea1f6878656"
+  integrity sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==
   dependencies:
     kind-of "^6.0.0"
 
 is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
+  integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
-is-callable@^1.1.1, is-callable@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz#86eb75392805ddc33af71c92a0eedf74ee7604b2"
-
-is-callable@^1.1.4:
+is-callable@^1.1.3, is-callable@^1.1.4:
   version "1.1.4"
   resolved "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
+  integrity sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==
 
 is-data-descriptor@^0.1.4:
   version "0.1.4"
   resolved "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz#0b5ee648388e2c860282e793f1856fec3f301b56"
+  integrity sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=
   dependencies:
     kind-of "^3.0.2"
 
 is-data-descriptor@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz#d84876321d0e7add03990406abbbbd36ba9268c7"
+  integrity sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==
   dependencies:
     kind-of "^6.0.0"
 
 is-date-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
+  integrity sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=
 
 is-descriptor@^0.1.0:
   version "0.1.6"
   resolved "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz#366d8240dde487ca51823b1ab9f07a10a78251ca"
+  integrity sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==
   dependencies:
     is-accessor-descriptor "^0.1.6"
     is-data-descriptor "^0.1.4"
@@ -699,6 +752,7 @@ is-descriptor@^0.1.0:
 is-descriptor@^1.0.0, is-descriptor@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz#3b159746a66604b04f8c81524ba365c5f14d86ec"
+  integrity sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==
   dependencies:
     is-accessor-descriptor "^1.0.0"
     is-data-descriptor "^1.0.0"
@@ -707,42 +761,33 @@ is-descriptor@^1.0.0, is-descriptor@^1.0.2:
 is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
   resolved "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
+  integrity sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=
 
 is-extendable@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz#a7470f9e426733d81bd81e1155264e3a3507cab4"
+  integrity sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==
   dependencies:
     is-plain-object "^2.0.4"
 
 is-finite@^1.0.1:
   version "1.0.2"
   resolved "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz#cc6677695602be550ef11e8b4aa6305342b6d0aa"
+  integrity sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=
   dependencies:
     number-is-nan "^1.0.0"
-
-is-function@~1.0.0:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz#12cfb98b65b57dd3d193a3121f5f6e2f437602b5"
 
 is-number@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
+  integrity sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=
   dependencies:
     kind-of "^3.0.2"
 
-is-number@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz#0026e37f5454d73e356dfe6564699867c6a7f0ff"
-
-is-odd@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz#7646624671fd7ea558ccd9a2795182f2958f1b24"
-  dependencies:
-    is-number "^4.0.0"
-
-is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
+is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
+  integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
   dependencies:
     isobject "^3.0.1"
 
@@ -756,50 +801,55 @@ is-plain-object@^3.0.0:
 is-regex@^1.0.4:
   version "1.0.4"
   resolved "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
+  integrity sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=
   dependencies:
     has "^1.0.1"
-
-is-symbol@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz#3cc59f00025194b6ab2e38dbae6689256b660572"
 
 is-symbol@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz#a055f6ae57192caee329e7a860118b497a950f38"
+  integrity sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==
   dependencies:
     has-symbols "^1.0.0"
 
 is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
+  integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
 
 isarray@0.0.1:
   version "0.0.1"
   resolved "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
 
 isarray@1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+  integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
 
 isemail@3.x.x:
-  version "3.1.2"
-  resolved "https://registry.npmjs.org/isemail/-/isemail-3.1.2.tgz#937cf919002077999a73ea8b1951d590e84e01dd"
+  version "3.2.0"
+  resolved "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz#59310a021931a9fb06bbb51e155ce0b3f236832c"
+  integrity sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==
   dependencies:
     punycode "2.x.x"
 
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
+  integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
 isobject@^2.0.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"
+  integrity sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=
   dependencies:
     isarray "1.0.0"
 
 isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
+  integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
 isobject@^4.0.0:
   version "4.0.0"
@@ -816,8 +866,9 @@ joi@14.3.1:
     topo "3.x.x"
 
 js-yaml@^3.2.7:
-  version "3.11.0"
-  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz#597c1a8bd57152f26d622ce4117851a51f5ebaef"
+  version "3.13.1"
+  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
+  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -839,32 +890,38 @@ jshint@2.10.2:
 json5@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
+  integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
   dependencies:
     minimist "^1.2.0"
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
+  integrity sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=
   dependencies:
     is-buffer "^1.1.5"
 
 kind-of@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz#20813df3d712928b207378691a45066fae72dd57"
+  integrity sha1-IIE989cSkosgc3hpGkUGb65y3Vc=
   dependencies:
     is-buffer "^1.1.5"
 
 kind-of@^5.0.0:
   version "5.1.0"
   resolved "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz#729c91e2d857b7a419a1f9aa65685c4c33f5845d"
+  integrity sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==
 
 kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.2"
   resolved "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
+  integrity sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==
 
 loader-utils@1.2.3:
   version "1.2.3"
   resolved "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz#1ff5dc6911c9f0a062531a4c04b609406108c2c7"
+  integrity sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==
   dependencies:
     big.js "^5.2.2"
     emojis-list "^2.0.0"
@@ -878,16 +935,19 @@ lodash@~4.17.11:
 map-cache@^0.2.2:
   version "0.2.2"
   resolved "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
+  integrity sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=
 
 map-visit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
+  integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
   dependencies:
     object-visit "^1.0.0"
 
 micromatch@3.1.10:
   version "3.1.10"
   resolved "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
+  integrity sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==
   dependencies:
     arr-diff "^4.0.0"
     array-unique "^0.3.2"
@@ -906,20 +966,24 @@ micromatch@3.1.10:
 minimatch@3.0.4, minimatch@^3.0.4, minimatch@~3.0.2:
   version "3.0.4"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
+  integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
   dependencies:
     brace-expansion "^1.1.7"
 
 minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
+  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
 
 minimist@^1.2.0, minimist@~1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
+  integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
 
 mixin-deep@^1.2.0:
-  version "1.3.1"
-  resolved "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz#a49e7268dce1a0d9698e45326c5626df3543d0fe"
+  version "1.3.2"
+  resolved "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz#1120b43dc359a785dce65b55b82e257ccf479566"
+  integrity sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==
   dependencies:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
@@ -927,12 +991,14 @@ mixin-deep@^1.2.0:
 mkdirp@0.5.1:
   version "0.5.1"
   resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
+  integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
 
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+  integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
 ms@2.1.2:
   version "2.1.2"
@@ -940,15 +1006,15 @@ ms@2.1.2:
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
 nanomatch@^1.2.9:
-  version "1.2.9"
-  resolved "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz#879f7150cb2dab7a471259066c104eee6e0fa7c2"
+  version "1.2.13"
+  resolved "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
+  integrity sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==
   dependencies:
     arr-diff "^4.0.0"
     array-unique "^0.3.2"
     define-property "^2.0.2"
     extend-shallow "^3.0.2"
     fragment-cache "^0.2.1"
-    is-odd "^2.0.0"
     is-windows "^1.0.2"
     kind-of "^6.0.2"
     object.pick "^1.3.0"
@@ -956,41 +1022,44 @@ nanomatch@^1.2.9:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-next-tick@1:
+next-tick@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
+  integrity sha1-yobR/ogoFpsBICCOPchCS524NCw=
 
 nice-try@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.npmjs.org/nice-try/-/nice-try-1.0.4.tgz#d93962f6c52f2c1558c0fbda6d512819f1efe1c4"
+  version "1.0.5"
+  resolved "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
+  integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
 number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
+  integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
 
 object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+  integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
 object-copy@^0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz#7e7d858b781bd7c991a41ba975ed3812754e998c"
+  integrity sha1-fn2Fi3gb18mRpBupde04EnVOmYw=
   dependencies:
     copy-descriptor "^0.1.0"
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-inspect@~1.5.0:
-  version "1.5.0"
-  resolved "https://registry.npmjs.org/object-inspect/-/object-inspect-1.5.0.tgz#9d876c11e40f485c79215670281b767488f9bfe3"
+object-inspect@^1.6.0, object-inspect@~1.6.0:
+  version "1.6.0"
+  resolved "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz#c70b6cbf72f274aab4c34c0c82f5167bf82cf15b"
+  integrity sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==
 
-object-keys@^1.0.12:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/object-keys/-/object-keys-1.1.0.tgz#11bd22348dd2e096a045ab06f6c85bcc340fa032"
-
-object-keys@^1.0.8:
-  version "1.0.11"
-  resolved "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
+object-keys@^1.0.12, object-keys@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
+  integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
 
 object-path-immutable@4.0.1:
   version "4.0.1"
@@ -1002,16 +1071,19 @@ object-path-immutable@4.0.1:
 object-path@0.11.4:
   version "0.11.4"
   resolved "https://registry.npmjs.org/object-path/-/object-path-0.11.4.tgz#370ae752fbf37de3ea70a861c23bba8915691949"
+  integrity sha1-NwrnUvvzfePqcKhhwju6iRVpGUk=
 
 object-visit@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz#f79c4493af0c5377b59fe39d395e41042dd045bb"
+  integrity sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=
   dependencies:
     isobject "^3.0.0"
 
 object.entries@1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz#2024fc6d6ba246aee38bdb0ffd5cfbcf371b7519"
+  integrity sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==
   dependencies:
     define-properties "^1.1.3"
     es-abstract "^1.12.0"
@@ -1021,12 +1093,14 @@ object.entries@1.1.0:
 object.pick@^1.3.0:
   version "1.3.0"
   resolved "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz#87a10ac4c1694bd2e1cbf53591a66141fb5dd747"
+  integrity sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=
   dependencies:
     isobject "^3.0.1"
 
 object.values@1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz#bf6810ef5da3e5325790eaaa2be213ea84624da9"
+  integrity sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==
   dependencies:
     define-properties "^1.1.3"
     es-abstract "^1.12.0"
@@ -1036,40 +1110,49 @@ object.values@1.1.0:
 once@^1.3.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
+  integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
   dependencies:
     wrappy "1"
 
 outdent@0.7.0:
   version "0.7.0"
   resolved "https://registry.npmjs.org/outdent/-/outdent-0.7.0.tgz#cfd1f1956305141e0cf3e898ada6547373c1997a"
+  integrity sha512-Ue462G+UIFoyQmOzapGIKWS3d/9NHeD/018WGEDZIhN2/VaQpVXbofMcZX0socv1fw4/tmEn7Vd3McOdPZfKzQ==
 
 parse-ms@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.1.tgz#56346d4749d78f23430ca0c713850aef91aa361d"
+  integrity sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0=
 
 pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
+  integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
 
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+  integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
 
 path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
+  integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
 
-path-parse@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
+path-parse@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
+  integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
 
 plur@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/plur/-/plur-1.0.0.tgz#db85c6814f5e5e5a3b49efc28d604fec62975156"
+  integrity sha1-24XGgU9eXlo7Se/CjWBP7GKXUVY=
 
 posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
+  integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
 
 postcss@7.0.18:
   version "7.0.18"
@@ -1083,35 +1166,41 @@ postcss@7.0.18:
 pretty-ms@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/pretty-ms/-/pretty-ms-2.1.0.tgz#4257c256df3fb0b451d6affaab021884126981dc"
+  integrity sha1-QlfCVt8/sLRR1q/6qwIYhBJpgdw=
   dependencies:
     is-finite "^1.0.1"
     parse-ms "^1.0.0"
     plur "^1.0.0"
 
 process-nextick-args@~2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
+  integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
 promise-compose@1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/promise-compose/-/promise-compose-1.1.2.tgz#c9bafebe4a649a81a3bfe02133e69a6ac5d32bb0"
+  integrity sha1-ybr+vkpkmoGjv+AhM+aaasXTK7A=
 
 punycode@2.x.x:
   version "2.1.1"
   resolved "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
+  integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
 readable-stream@1.1:
   version "1.1.13"
   resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz#f6eef764f514c89e2b9e23146a75ba106756d23e"
+  integrity sha1-9u73ZPUUyJ4rniMUanW6EGdW0j4=
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.1"
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readable-stream@^2, readable-stream@^2.1.5:
+readable-stream@^2, readable-stream@~2.3.6:
   version "2.3.6"
   resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
+  integrity sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.3"
@@ -1124,12 +1213,14 @@ readable-stream@^2, readable-stream@^2.1.5:
 recursive-readdir@2.2.2:
   version "2.2.2"
   resolved "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.2.tgz#9946fb3274e1628de6e36b2f6714953b4845094f"
+  integrity sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==
   dependencies:
     minimatch "3.0.4"
 
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz#1f4ece27e00b0b65e0247a6810e6a85d83a5752c"
+  integrity sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==
   dependencies:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
@@ -1137,42 +1228,51 @@ regex-not@^1.0.0, regex-not@^1.0.2:
 regex-parser@2.2.10:
   version "2.2.10"
   resolved "https://registry.npmjs.org/regex-parser/-/regex-parser-2.2.10.tgz#9e66a8f73d89a107616e63b39d4deddfee912b37"
+  integrity sha512-8t6074A68gHfU8Neftl0Le6KTDwfGAj7IyjPIMSfikI2wJUTHDMaIq42bUsfVnj8mhx0R+45rdUXHGpN164avA==
 
 repeat-element@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz#ef089a178d1483baae4d93eb98b4f9e4e11d990a"
+  version "1.1.3"
+  resolved "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz#782e0d825c0c5a3bb39731f84efee6b742e6b1ce"
+  integrity sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==
 
 repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
+  integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
 
 resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
+  integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@~1.5.0:
-  version "1.5.0"
-  resolved "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
+resolve@~1.11.1:
+  version "1.11.1"
+  resolved "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz#ea10d8110376982fef578df8fc30b9ac30a07a3e"
+  integrity sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==
   dependencies:
-    path-parse "^1.0.5"
+    path-parse "^1.0.6"
 
 resumer@~0.0.0:
   version "0.0.0"
   resolved "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz#f1e8f461e4064ba39e82af3cdc2a8c893d076759"
+  integrity sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=
   dependencies:
     through "~2.3.4"
 
 ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
+  integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
 rework-visit@1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/rework-visit/-/rework-visit-1.0.0.tgz#9945b2803f219e2f7aca00adb8bc9f640f842c9a"
+  integrity sha1-mUWygD8hni96ygCtuLyfZA+ELJo=
 
 rework@1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/rework/-/rework-1.0.1.tgz#30806a841342b54510aa4110850cd48534144aa7"
+  integrity sha1-MIBqhBNCtUUQqkEQhQzUhTQUSqc=
   dependencies:
     convert-source-map "^0.3.3"
     css "^2.0.0"
@@ -1187,29 +1287,24 @@ rimraf@3.0.0:
 safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
 safe-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz#40a3669f3b077d1e943d44629e157dd48023bf2e"
+  integrity sha1-QKNmnzsHfR6UPURinhV91IAjvy4=
   dependencies:
     ret "~0.1.10"
 
 semver@^5.5.0:
-  version "5.5.0"
-  resolved "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
+  version "5.7.1"
+  resolved "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
+  integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-set-value@^0.4.3:
-  version "0.4.3"
-  resolved "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz#7db08f9d3d22dc7f78e53af3c3bf4666ecdfccf1"
-  dependencies:
-    extend-shallow "^2.0.1"
-    is-extendable "^0.1.1"
-    is-plain-object "^2.0.1"
-    to-object-path "^0.3.0"
-
-set-value@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz#71ae4a88f0feefbbf52d1ea604f3fb315ebb6274"
+set-value@^2.0.0, set-value@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz#a18d40530e6f07de4228c7defe4227af8cad005b"
+  integrity sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==
   dependencies:
     extend-shallow "^2.0.1"
     is-extendable "^0.1.1"
@@ -1219,20 +1314,24 @@ set-value@^2.0.0:
 shebang-command@^1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
+  integrity sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=
   dependencies:
     shebang-regex "^1.0.0"
 
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
+  integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
 
 shelljs@0.3.x:
   version "0.3.0"
   resolved "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz#3596e6307a781544f591f37da618360f31db57b1"
+  integrity sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=
 
 snapdragon-node@^2.0.1:
   version "2.1.1"
   resolved "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
+  integrity sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==
   dependencies:
     define-property "^1.0.0"
     isobject "^3.0.0"
@@ -1241,12 +1340,14 @@ snapdragon-node@^2.0.1:
 snapdragon-util@^3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz#f956479486f2acd79700693f6f7b805e45ab56e2"
+  integrity sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==
   dependencies:
     kind-of "^3.2.0"
 
 snapdragon@^0.8.1:
   version "0.8.2"
   resolved "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz#64922e7c565b0e14204ba1aa7d6964278d25182d"
+  integrity sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==
   dependencies:
     base "^0.11.1"
     debug "^2.2.0"
@@ -1257,9 +1358,10 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
-source-map-resolve@^0.5.0, source-map-resolve@^0.5.1:
+source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
   version "0.5.2"
   resolved "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz#72e2cc34095543e43b2c62b2c4c10d4a9054f259"
+  integrity sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==
   dependencies:
     atob "^2.1.1"
     decode-uri-component "^0.2.0"
@@ -1270,34 +1372,34 @@ source-map-resolve@^0.5.0, source-map-resolve@^0.5.1:
 source-map-url@^0.4.0:
   version "0.4.0"
   resolved "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
+  integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
 
 source-map@0.6.1, source-map@^0.6.1:
   version "0.6.1"
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
-
-source-map@^0.1.38:
-  version "0.1.43"
-  resolved "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz#c24bc146ca517c1471f5dacbe2571b2b7f9e3346"
-  dependencies:
-    amdefine ">=0.0.4"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
 source-map@^0.5.6:
   version "0.5.7"
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+  integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
+  integrity sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==
   dependencies:
     extend-shallow "^3.0.0"
 
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+  integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
 static-extend@^0.1.1:
   version "0.1.2"
   resolved "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
+  integrity sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=
   dependencies:
     define-property "^0.2.5"
     object-copy "^0.1.0"
@@ -1305,6 +1407,7 @@ static-extend@^0.1.1:
 string.prototype.padstart@3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/string.prototype.padstart/-/string.prototype.padstart-3.0.0.tgz#5bcfad39f4649bb2d031292e19bcf0b510d4b242"
+  integrity sha1-W8+tOfRkm7LQMSkuGbzwtRDUskI=
   dependencies:
     define-properties "^1.1.2"
     es-abstract "^1.4.3"
@@ -1313,50 +1416,75 @@ string.prototype.padstart@3.0.0:
 string.prototype.trim@~1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz#d04de2c89e137f4d7d206f086b5ed2fae6be8cea"
+  integrity sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=
   dependencies:
     define-properties "^1.1.2"
     es-abstract "^1.5.0"
     function-bind "^1.0.2"
 
+string.prototype.trimleft@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz#6cc47f0d7eb8d62b0f3701611715a3954591d634"
+  integrity sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==
+  dependencies:
+    define-properties "^1.1.3"
+    function-bind "^1.1.1"
+
+string.prototype.trimright@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz#669d164be9df9b6f7559fa8e89945b168a5a6c58"
+  integrity sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==
+  dependencies:
+    define-properties "^1.1.3"
+    function-bind "^1.1.1"
+
 string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
+  integrity sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=
 
 string_decoder@~1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
   dependencies:
     safe-buffer "~5.1.0"
 
 strip-ansi@^3.0.0:
   version "3.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
+  integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
   dependencies:
     ansi-regex "^2.0.0"
 
 strip-json-comments@1.0.x:
   version "1.0.4"
   resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz#1e15fbcac97d3ee99bf2d73b4c656b082bbafb91"
+  integrity sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=
 
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
+  integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
 
 supports-color@^5.3.0:
-  version "5.4.0"
-  resolved "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
+  version "5.5.0"
+  resolved "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
+  integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
   dependencies:
     has-flag "^3.0.0"
 
 supports-color@^6.1.0:
   version "6.1.0"
   resolved "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz#0764abc69c63d5ac842dd4867e8d025e880df8f3"
+  integrity sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==
   dependencies:
     has-flag "^3.0.0"
 
 tap-diff@0.1.1:
   version "0.1.1"
   resolved "https://registry.npmjs.org/tap-diff/-/tap-diff-0.1.1.tgz#8fbf3333d85643feea1bf1759b90820b04a37ddf"
+  integrity sha1-j78zM9hWQ/7qG/F1m5CCCwSjfd8=
   dependencies:
     chalk "^1.1.1"
     diff "^2.2.1"
@@ -1369,6 +1497,7 @@ tap-diff@0.1.1:
 tap-parser@^1.2.2:
   version "1.3.2"
   resolved "https://registry.npmjs.org/tap-parser/-/tap-parser-1.3.2.tgz#120c5089c88c3c8a793ef288867de321e18f8c22"
+  integrity sha1-EgxQiciMPIp5PvKIhn3jIeGPjCI=
   dependencies:
     events-to-array "^1.0.1"
     inherits "~2.0.1"
@@ -1377,43 +1506,48 @@ tap-parser@^1.2.2:
     readable-stream "^2"
 
 "tape@>=2.0.0 <5.0.0":
-  version "4.9.0"
-  resolved "https://registry.npmjs.org/tape/-/tape-4.9.0.tgz#855c08360395133709d34d3fbf9ef341eb73ca6a"
+  version "4.11.0"
+  resolved "https://registry.npmjs.org/tape/-/tape-4.11.0.tgz#63d41accd95e45a23a874473051c57fdbc58edc1"
+  integrity sha512-yixvDMX7q7JIs/omJSzSZrqulOV51EC9dK8dM0TzImTIkHWfe2/kFyL5v+d9C+SrCMaICk59ujsqFAVidDqDaA==
   dependencies:
     deep-equal "~1.0.1"
     defined "~1.0.0"
-    for-each "~0.3.2"
+    for-each "~0.3.3"
     function-bind "~1.1.1"
-    glob "~7.1.2"
-    has "~1.0.1"
-    inherits "~2.0.3"
+    glob "~7.1.4"
+    has "~1.0.3"
+    inherits "~2.0.4"
     minimist "~1.2.0"
-    object-inspect "~1.5.0"
-    resolve "~1.5.0"
+    object-inspect "~1.6.0"
+    resolve "~1.11.1"
     resumer "~0.0.0"
     string.prototype.trim "~1.1.2"
     through "~2.3.8"
 
 through2@^2.0.0:
-  version "2.0.3"
-  resolved "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz#0004569b37c7c74ba39c43f3ced78d1ad94140be"
+  version "2.0.5"
+  resolved "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"
+  integrity sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==
   dependencies:
-    readable-stream "^2.1.5"
+    readable-stream "~2.3.6"
     xtend "~4.0.1"
 
 through@~2.3.4, through@~2.3.8:
   version "2.3.8"
   resolved "https://registry.npmjs.org/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
+  integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
 
 to-object-path@^0.3.0:
   version "0.3.0"
   resolved "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz#297588b7b0e7e0ac08e04e672f85c1f4999e17af"
+  integrity sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=
   dependencies:
     kind-of "^3.0.2"
 
 to-regex-range@^2.1.0:
   version "2.1.1"
   resolved "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz#7c80c17b9dfebe599e27367e0d4dd5590141db38"
+  integrity sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=
   dependencies:
     is-number "^3.0.0"
     repeat-string "^1.6.1"
@@ -1421,6 +1555,7 @@ to-regex-range@^2.1.0:
 to-regex@^3.0.1, to-regex@^3.0.2:
   version "3.0.2"
   resolved "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz#13cfdd9b336552f30b51f33a8ae1b42a7a7599ce"
+  integrity sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==
   dependencies:
     define-property "^2.0.2"
     extend-shallow "^3.0.2"
@@ -1434,18 +1569,25 @@ topo@3.x.x:
   dependencies:
     hoek "6.x.x"
 
+type@^1.0.1:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/type/-/type-1.2.0.tgz#848dd7698dafa3e54a6c479e759c4bc3f18847a0"
+  integrity sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==
+
 union-value@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz#5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4"
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz#0b6fe7b835aecda61c6ea4d4f02c14221e109847"
+  integrity sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==
   dependencies:
     arr-union "^3.1.0"
     get-value "^2.0.6"
     is-extendable "^0.1.1"
-    set-value "^0.4.3"
+    set-value "^2.0.1"
 
 unset-value@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz#8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559"
+  integrity sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=
   dependencies:
     has-value "^0.3.1"
     isobject "^3.0.0"
@@ -1453,20 +1595,22 @@ unset-value@^1.0.0:
 urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
+  integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
 
 use@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.npmjs.org/use/-/use-3.1.0.tgz#14716bf03fdfefd03040aef58d8b4b85f3a7c544"
-  dependencies:
-    kind-of "^6.0.2"
+  version "3.1.1"
+  resolved "https://registry.npmjs.org/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
+  integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
 util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+  integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
 util@0.10.3:
   version "0.10.3"
   resolved "https://registry.npmjs.org/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
+  integrity sha1-evsa/lCAUkZInj23/g7TeTNqwPk=
   dependencies:
     inherits "2.0.1"
 
@@ -1476,15 +1620,18 @@ vlq@1.0.1:
   integrity sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==
 
 which@^1.2.9:
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
+  version "1.3.1"
+  resolved "https://registry.npmjs.org/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
+  integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
   dependencies:
     isexe "^2.0.0"
 
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+  integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
 xtend@~4.0.1:
-  version "4.0.1"
-  resolved "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
+  version "4.0.2"
+  resolved "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
+  integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -136,6 +136,11 @@ camelcase@5.0.0:
   version "5.0.0"
   resolved "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz#03295527d58bd3cd4aa75363f35b2e8d97be2f42"
 
+"camelcase@5.3.1 ":
+  version "5.3.1"
+  resolved "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
+  integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
+
 chalk@^1.1.1:
   version "1.1.3"
   resolved "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -225,12 +230,12 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-cross-env@5.2.0:
-  version "5.2.0"
-  resolved "https://registry.npmjs.org/cross-env/-/cross-env-5.2.0.tgz#6ecd4c015d5773e614039ee529076669b9d126f2"
+cross-env@5.2.1:
+  version "5.2.1"
+  resolved "https://registry.npmjs.org/cross-env/-/cross-env-5.2.1.tgz#b2c76c1ca7add66dc874d11798466094f551b34d"
+  integrity sha512-1yHhtcfAd1r4nwQgknowuUNfIT9E8dOMMspC36g45dN+iD1blloi7xp8X/xAIDnjHWyt1uQ8PHk2fkNaym7soQ==
   dependencies:
     cross-spawn "^6.0.5"
-    is-windows "^1.0.0"
 
 cross-spawn@6.0.5, cross-spawn@^6.0.5:
   version "6.0.5"
@@ -412,9 +417,10 @@ es6-iterator@2.0.3, es6-iterator@~2.0.3:
     es5-ext "^0.10.35"
     es6-symbol "^3.1.1"
 
-es6-promisify@6.0.1:
-  version "6.0.1"
-  resolved "https://registry.npmjs.org/es6-promisify/-/es6-promisify-6.0.1.tgz#6edaa45f3bd570ffe08febce66f7116be4b1cdb6"
+es6-promisify@6.0.2:
+  version "6.0.2"
+  resolved "https://registry.npmjs.org/es6-promisify/-/es6-promisify-6.0.2.tgz#525c23725b8510f5f1f2feb5a1fbad93a93e29b4"
+  integrity sha512-eO6vFm0JvqGzjWIQA6QVKjxpmELfhWbDUWHm1rPfIbn55mhKPiAa5xpLmQWJrNa629ZIeQ8ZvMAi13kvrjK6Mg==
 
 es6-symbol@^3.1.1, es6-symbol@~3.1.1:
   version "3.1.1"
@@ -612,9 +618,10 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
-hoek@4.x.x:
-  version "4.2.1"
-  resolved "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
+hoek@6.x.x:
+  version "6.1.3"
+  resolved "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz#73b7d33952e01fe27a38b0457294b79dd8da242c"
+  integrity sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ==
 
 htmlparser2@3.8.x:
   version "3.8.3"
@@ -739,6 +746,13 @@ is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   dependencies:
     isobject "^3.0.1"
 
+is-plain-object@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz#47bfc5da1b5d50d64110806c199359482e75a928"
+  integrity sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==
+  dependencies:
+    isobject "^4.0.0"
+
 is-regex@^1.0.4:
   version "1.0.4"
   resolved "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
@@ -755,7 +769,7 @@ is-symbol@^1.0.2:
   dependencies:
     has-symbols "^1.0.0"
 
-is-windows@^1.0.0, is-windows@^1.0.2:
+is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
 
@@ -787,13 +801,19 @@ isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
 
-joi@12.0.0:
-  version "12.0.0"
-  resolved "https://registry.npmjs.org/joi/-/joi-12.0.0.tgz#46f55e68f4d9628f01bbb695902c8b307ad8d33a"
+isobject@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz#3f1c9155e73b192022a80819bacd0343711697b0"
+  integrity sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==
+
+joi@14.3.1:
+  version "14.3.1"
+  resolved "https://registry.npmjs.org/joi/-/joi-14.3.1.tgz#164a262ec0b855466e0c35eea2a885ae8b6c703c"
+  integrity sha512-LQDdM+pkOrpAn4Lp+neNIFV3axv1Vna3j38bisbQhETPMANYRbFJFUyOZcOClYvM/hppMhGWuKSFEK9vjrB+bQ==
   dependencies:
-    hoek "4.x.x"
+    hoek "6.x.x"
     isemail "3.x.x"
-    topo "2.x.x"
+    topo "3.x.x"
 
 js-yaml@^3.2.7:
   version "3.11.0"
@@ -802,15 +822,16 @@ js-yaml@^3.2.7:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-jshint@2.10.1:
-  version "2.10.1"
-  resolved "https://registry.npmjs.org/jshint/-/jshint-2.10.1.tgz#06bd4cea090c424405aa0987de741341ff17f6bc"
+jshint@2.10.2:
+  version "2.10.2"
+  resolved "https://registry.npmjs.org/jshint/-/jshint-2.10.2.tgz#ed6626c4f8223c98e94aaea62767435427a49a3d"
+  integrity sha512-e7KZgCSXMJxznE/4WULzybCMNXNAd/bf5TSrvVEq78Q/K8ZwFpmBqQeDtNiHc3l49nV4E/+YeHU/JZjSUIrLAA==
   dependencies:
     cli "~1.0.0"
     console-browserify "1.1.x"
     exit "0.1.x"
     htmlparser2 "3.8.x"
-    lodash "~4.17.10"
+    lodash "~4.17.11"
     minimatch "~3.0.2"
     shelljs "0.3.x"
     strip-json-comments "1.0.x"
@@ -849,9 +870,10 @@ loader-utils@1.2.3:
     emojis-list "^2.0.0"
     json5 "^1.0.1"
 
-lodash@~4.17.10:
-  version "4.17.11"
-  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+lodash@~4.17.11:
+  version "4.17.15"
+  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
 map-cache@^0.2.2:
   version "0.2.2"
@@ -912,9 +934,10 @@ ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
-ms@2.1.1:
-  version "2.1.1"
-  resolved "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
+ms@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
+  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
 nanomatch@^1.2.9:
   version "1.2.9"
@@ -969,11 +992,12 @@ object-keys@^1.0.8:
   version "1.0.11"
   resolved "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
 
-object-path-immutable@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/object-path-immutable/-/object-path-immutable-3.0.0.tgz#c242a7e6648c64e37bd9f363bbf2fb91ced69ff5"
+object-path-immutable@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.npmjs.org/object-path-immutable/-/object-path-immutable-4.0.1.tgz#81852e4250338c9466c3abe75967e0957fd33505"
+  integrity sha512-LpHpch+lSpJGUop4rnxqtyPcXAMeZZWqr8jev/419v7vRrpJhgI/sPDY6XJKnAREYQGM5pSWLamQo5usP5jwiw==
   dependencies:
-    is-plain-object "^2.0.4"
+    is-plain-object "^3.0.0"
 
 object-path@0.11.4:
   version "0.11.4"
@@ -1047,9 +1071,10 @@ posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
 
-postcss@7.0.14:
-  version "7.0.14"
-  resolved "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz#4527ed6b1ca0d82c53ce5ec1a2041c2346bbd6e5"
+postcss@7.0.18:
+  version "7.0.18"
+  resolved "https://registry.npmjs.org/postcss/-/postcss-7.0.18.tgz#4b9cda95ae6c069c67a4d933029eddd4838ac233"
+  integrity sha512-/7g1QXXgegpF+9GJj4iN7ChGF40sYuGYJ8WZu8DZWnmhQ/G36hfdk3q9LBJmoK+lZ+yzZ5KYpOoxq7LF1BxE8g==
   dependencies:
     chalk "^2.4.2"
     source-map "^0.6.1"
@@ -1152,9 +1177,10 @@ rework@1.0.1:
     convert-source-map "^0.3.3"
     css "^2.0.0"
 
-rimraf@2.6.3:
-  version "2.6.3"
-  resolved "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
+rimraf@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/rimraf/-/rimraf-3.0.0.tgz#614176d4b3010b75e5c390eb0ee96f6dc0cebb9b"
+  integrity sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==
   dependencies:
     glob "^7.1.3"
 
@@ -1401,11 +1427,12 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
-topo@2.x.x:
-  version "2.0.2"
-  resolved "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz#cd5615752539057c0dc0491a621c3bc6fbe1d182"
+topo@3.x.x:
+  version "3.0.3"
+  resolved "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz#d5a67fb2e69307ebeeb08402ec2a2a6f5f7ad95c"
+  integrity sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==
   dependencies:
-    hoek "4.x.x"
+    hoek "6.x.x"
 
 union-value@^1.0.0:
   version "1.0.0"
@@ -1443,9 +1470,10 @@ util@0.10.3:
   dependencies:
     inherits "2.0.1"
 
-vlq@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/vlq/-/vlq-1.0.0.tgz#8101be90843422954c2b13eb27f2f3122bdcc806"
+vlq@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/vlq/-/vlq-1.0.1.tgz#c003f6e7c0b4c1edd623fd6ee50bbc0d6a1de468"
+  integrity sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==
 
 which@^1.2.9:
   version "1.3.0"


### PR DESCRIPTION
Triggered by #126.

Utilise multiple apparent start positions available in the postcss AST
* support `url()` defined within in a `$variable` relative to that variable definition
* support `url()` generated by a `@mixin` but relative to the `@include`
* resolve source-map only where transforming the declaration, not for every `url()` statement

Additionally
* support package symlinking from the monorepo root
* update dependencies (supersedes #128).