### PR TITLE
Refactor join function

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "lint": "jshint packages --exclude **/node_modules",
-    "test:unit": "tape **/*.test.js | tap-diff",
+    "test:unit": "tape \"!(node_modules)/**/*.test.js\" | tap-diff",
     "debug:unit": "node $NODE_DEBUG_OPTION $(npm bin)/tape **/*.test.js | tap-diff",
     "test:e2e": "tape test | tap-diff",
     "debug:e2e": "node $NODE_DEBUG_OPTION $(npm bin)/tape test | tap-diff"
@@ -30,6 +30,7 @@
     "outdent": "0.7.0",
     "promise-compose": "1.1.2",
     "recursive-readdir": "2.2.2",
+    "sinon": "^8.0.2",
     "tap-diff": "0.1.1",
     "vlq": "1.0.1"
   },

--- a/packages/resolve-url-loader/README.md
+++ b/packages/resolve-url-loader/README.md
@@ -147,49 +147,30 @@ A [rework](https://github.com/reworkcss/rework) or [postcss](https://postcss.org
 
 Each `url()` statement may imply an asset or may not. Generally only relative URIs are considered. However if `root` is specified then absolute or root-relative URIs are considered.
 
-For each URI considered, the incomming source-map is consulted to determine the original file where the `url()` was specified. This becomes the `base` argument to the `join` function, whose default implementation is something like the following pseudocode.
+For each URI considered, the incomming source-map is consulted to determine the original file where the `url()` was specified. This becomes the `base` argument to the `join` function.
+The `join` function essentially concatenates the `base` with the URI in question.
 
-```javascript
-join(uri: Iterator<sring>, base: ?string) =>
-  // first value of iterator where file exists
-  compose(path.normalize, path.join)(base || options.join, uri);
-```
 
-Note that for absolute `uri` then the `base` is absent. In the default implementation the `root` option is used instead.
+However there may be more than one possible `base` depending on where we consult the source-map. The `join` function will therefore test there is a file at the concatenated file path. If not it may use a different `base`. Use the `debug` option to see verbose information from the `join` function.
 
-Full file search has been discontinued in version 3, however it is possible to specify a custom `join` function.
-
-There is the added complexity that `base` may be an iterator. However `resolve-url-loader` exports some useful functions that makes a custom `join` easier.
+Note that for absolute URI the `base` is absent. In the default implementation the value of the `root` option is used in place of `base`.
 
 Following `join` the URI has become an absolute path. Back-slashes are then converted to forward-slashes and the path is made relative to the initial resource being considered.
 
-Use the `debug` option to see verbose information from the `join` function.
+Full file-system search was discontinued in version 3, however it is possible to specify a custom `join` function to achieve a similar result.
+We export some useful functions that makes a custom `join` easier.
 
 ## Limitations / Known-issues
 
-### Mixins
-
-Where `url()` statements are created in a mixin the source file may then be the mixin file, and not the file calling the mixin. Obviously this is **not** the desired behaviour.
-
-Ensure this is indeed the problem as there are many ways to misconfigure webpack. Try inlining the mixin and check that everything works correctly. However ultimately you will need to work around this.
-
 ### Compatiblity
 
-Tested `macOS` and `Windows` for `node 6.x`.
+Tested `macOS` and `Windows` for `node 8`.
 
-All `webpack1`-`webpack4` with contemporaneous loaders/plugins.
+All `webpack2`-`webpack4` with contemporaneous loaders/plugins.
 
 Refer to `test` directory for full webpack configurations (as used in automated tests).
 
 Some edge cases with `libsass` on `Windows` (see below).
-
-### Engines
-
-The `engine:postcss` is by far the more reliable option.
-
-The `engine:rework` option is retained for historical compatibility but is likely to be removed in the future, so let me know if you use it.
-
-If you need production css source-map it is best to avoid the combination `webpack4` with `engine:rework`. Tests show a systematic flaw in the outgoing source-map mappings.
 
 ### Absolute URIs
 
@@ -263,4 +244,4 @@ I am happy to take **pull requests**, however:
 * Uncomon use-cases/fixes should be opt-in per a new **option**.
 * Do **not** overwrite existing variables with new values. I would prefer your change variable names elsewhere if necessary.
 * Add **comments** that describe why the code is necessary - i.e. what edge case are we solving. Otherwise we may rewrite later and break your use-case.
-* If I ask for changes to the PR  then you need to do them to get commit credit. Otherwise I can make the change but may drop your PR.
+* If I ask for changes to the PR then you need to do them to get commit credit. Otherwise I can make the change but may drop your PR.

--- a/packages/resolve-url-loader/index.js
+++ b/packages/resolve-url-loader/index.js
@@ -45,6 +45,7 @@ function resolveUrlLoader(content, sourceMap) {
   var rawOptions = loaderUtils.getOptions(loader),
       options    = Object.assign(
         {
+          fs       : loader.fs,
           sourceMap: loader.sourceMap,
           engine   : 'postcss',
           silent   : false,
@@ -57,7 +58,12 @@ function resolveUrlLoader(content, sourceMap) {
       );
 
   // maybe log options for the test harness
-  logToTestHarness(options);
+  if (process.env.RESOLVE_URL_LOADER_TEST_HARNESS) {
+    logToTestHarness(
+      process[process.env.RESOLVE_URL_LOADER_TEST_HARNESS],
+      options
+    );
+  }
 
   // deprecated options
   if ('engine' in rawOptions) {

--- a/packages/resolve-url-loader/lib/engine/rework.js
+++ b/packages/resolve-url-loader/lib/engine/rework.js
@@ -79,23 +79,30 @@ function process(sourceFile, sourceContent, params) {
       }
 
       /**
-       * Create a list of base path strings.
+       * Create a hash of base path strings.
        *
        * Position in the declaration is not supported since rework does not refine sourcemaps to this detail.
        *
        * @throws Error on invalid source map
-       * @returns {string[]} Iterable of base path strings possibly empty
+       * @returns {{selector:string, property:string}} Hash of base path strings
        */
       function getPathsAtChar() {
-        var directory = positionToOriginalDirectory(declaration.position.start);
-        if (directory) {
-          return [directory];
+        var posSelector = declaration.parent && declaration.parent.position.start,
+            posProperty = declaration.position.start;
+
+        var result = {
+          property: positionToOriginalDirectory(posProperty),
+          selector: positionToOriginalDirectory(posSelector)
+        };
+
+        var isValid = [result.property, result.selector].every(Boolean);
+        if (isValid) {
+          return result;
         }
-        // source-map present but invalid entry
         else if (params.sourceMapConsumer) {
           throw new Error('source-map information is not available at url() declaration');
         } else {
-          return [];
+          throw new Error('a valid source-map is not present (ensure preceding loaders output a source-map)');
         }
       }
     }

--- a/packages/resolve-url-loader/lib/join-function.js
+++ b/packages/resolve-url-loader/lib/join-function.js
@@ -5,13 +5,68 @@
 'use strict';
 
 var path     = require('path'),
-    fs       = require('fs'),
     compose  = require('compose-function'),
-    Iterator = require('es6-iterator');
+    Iterator = require('es6-iterator'),
+    Symbol   = require('es6-symbol');
 
 var PACKAGE_NAME = require('../package.json').name;
 
 var simpleJoin = compose(path.normalize, path.join);
+
+/**
+ * Webpack `fs` from `enhanced-resolve` doesn't support `existsSync()` so we shim using `statsSync()`.
+ *
+ * @param {{statSync:function(string):boolean}} webpackFs The webpack `fs` from `loader.fs`.
+ * @param {string} absolutePath Absolute path to the file in question
+ * @returns {boolean} True where file exists, else False
+ */
+function testIsFile(webpackFs, absolutePath) {
+  try {
+    return webpackFs.statSync(absolutePath).isFile();
+  } catch (e) {
+    return false;
+  }
+}
+
+exports.testIsFile = testIsFile;
+
+/**
+ * The default factory will order `subString` then `value` then `property` then `selector`.
+ *
+ * @param {string} _filename (unused) The currently processed file
+ * @param {{subString:string, value:string, property:string, selector:string}|null} bases A hash of possible base paths
+ * @param {{fs:Object, root:string}} options The loader options including webpack file system
+ * @returns {Array<string>} An iterable of possible base paths in preference order
+ */
+function defaultJoinFactory(_filename, bases, options) {
+  return bases ? [bases.subString, bases.value, bases.property, bases.selector] : [options.root];
+}
+
+exports.defaultJoinFactory = defaultJoinFactory;
+
+/**
+ * The default predicate simply joins the given base to the uri and returns it where it exists.
+ *
+ * The result of `next()` represents the eventual result and needs to be returned otherwise.
+ *
+ * If none of the expected files exist then the first candidate is returned as a "default" value, even if it doesn't
+ * exist.
+ *
+ * @param {string} _filename (unused) The currently processed file
+ * @param {string} uri The value in the url() statement being processed
+ * @param {string} base A possible base path
+ * @param {number} i The index in the iterator
+ * @param {function(string|null):string} next Rerun with the next value from the iterator, with possible default result
+ * @param {{fs:Object, root:string}} options The loader options including webpack file system
+ * @returns {*}
+ */
+function defaultJoinPredicate(_filename, uri, base, i, next, options) {
+  var absolute = simpleJoin(base, uri),
+      isFile   = testIsFile(options.fs, absolute);
+  return isFile ? absolute : next((i === 0) ? absolute : null);
+}
+
+exports.defaultJoinPredicate = defaultJoinPredicate;
 
 /**
  * The default join function iterates over possible base paths until a suitable join is found.
@@ -20,43 +75,69 @@ var simpleJoin = compose(path.normalize, path.join);
  *
  * @type {function}
  */
-exports.defaultJoin = createJoinForPredicate(
-  function predicate(_, uri, base, i, next) {
-    var absolute = simpleJoin(base, uri);
-    return fs.existsSync(absolute) ? absolute : next((i === 0) ? absolute : null);
-  },
-  'defaultJoin'
+exports.defaultJoin = createJoinFunction(
+  'defaultJoin',
+  defaultJoinFactory,
+  defaultJoinPredicate
 );
 
 /**
- * Define a join function by a predicate that tests possible base paths from an iterator.
+ * Define a join function by `factory` and `predicate` functions.
  *
- * The `predicate` is of the form:
+ * You can write a much simpler function than this if you have specific requirements. But it can also be useful to just
+ * write custom `factory` or `predicate` functions.
+ *
+ * The `factory` is called for relative URIs to order/iterate the possible base paths. It is of the form:
  *
  * ```
- * function(filename, uri, base, i, next):string|null
+ * function(filename, bases, options):Array<string>|Iterator<string>
  * ```
  *
- * Given the uri and base it should either return:
- * - an absolute path success
- * - a call to `next(null)` as failure
- * - a call to `next(absolute)` where absolute is placeholder and the iterator continues
+ * where
+ * - `filename` The currently processed file
+ * - `bases` A hash of possible base paths or `null` for absolute URIs
+ * - `options` The loader options (including webpack `fs`)
  *
- * The value given to `next(...)` is only used if success does not eventually occur.
+ * returns
+ * - an ordered Array or Iterator of possible base path strings, usually an enumeration of `bases`
  *
- * The `file` value is typically unused but useful if you would like to differentiate behaviour.
+ * The `predicate` is applied to each value of the iterator given by the `factory` as a possible base path.
+ * The `predicate` tests the base against the URI and determines whether it is a match.
  *
- * You can write a much simpler function than this if you have specific requirements.
+ * ```
+ * function(filename, uri, base, i, next, options):string|null
+ * ```
  *
- * @param {function} predicate A function that tests values
- * @param {string} [name] Optional name for the resulting join function
+ * where
+ * - `filename` The currently processed file
+ * - `uri` The value in the url() statement being processed
+ * - `base` A possible base path
+ * - `i` The index in the iterator
+ * - `next` Rerun with the next value from the iterator, passing default result
+ * - `options` The loader options (including webpack `fs`)
+ *
+ * returns
+ * - an absolute path on success
+ * - a call to `next(null)` on failure
+ * - a call to `next(absolute)` on failure where absolute is placeholder
+ *
+ * The string argument `x` given in the last `next(x)` call is used if success does not eventually occur.
+ *
+ * The `filename` value is typically unused but useful if you would like to differentiate behaviour.
+ *
+ * @param {string} name Name for the resulting join function
+ * @param {function(Object):Iterator<string>} factory A function that takes the hash of base paths from the `engine` and
+ *  returns ordered iteratable of paths to consider
+ * @param {function} predicate A function that tests values and returns joined paths
  */
-function createJoinForPredicate(predicate, name) {
+function createJoinFunction(name, factory, predicate) {
+  var safeFactory = compose(ensureIterator, factory);
+
   /**
    * A factory for a join function with logging.
    *
    * @param {string} filename The current file being processed
-   * @param {{debug:function|boolean,root:string}} options An options hash
+   * @param {{fs:Object, debug:function|boolean, root:string}} options An options hash
    */
   function join(filename, options) {
     var log = createDebugLogger(options.debug);
@@ -64,69 +145,109 @@ function createJoinForPredicate(predicate, name) {
     /**
      * Join function proper.
      *
-     * For absolute uri only `uri` will be provided. In this case we substitute any `root` given in options.
+     * For absolute uri only `uri` will be provided and no `bases`.
      *
      * @param {string} uri A uri path, relative or absolute
-     * @param {Iterator<string>} [maybeIterator] Optional iterator of absolute base path strings
+     * @param {{subString:string, value:string, property:string, selector:string}} [maybeBases] Optional hash of
+     *  possible base paths
      * @return {string} Just the uri where base is empty or the uri appended to the base
      */
-    return function joinProper(uri, maybeIterator) {
-      var iterator = typeof maybeIterator === 'undefined' ? new Iterator([options.root]) : maybeIterator;
+    return function joinProper(uri, bases) {
+      var iterator = safeFactory(filename, bases, options),
+          result   = runIterator(createAccumulator());
 
-      var result = runIterator([]);
-      log(createJoinMsg, [filename, uri, result, result.isFound]);
+      log(createJoinMsg, [filename, uri, result.list, result.isFound]);
 
       return (typeof result.absolute === 'string') ? result.absolute : uri;
 
+      /**
+       * Run the next iterator value and use the accumulator.
+       *
+       * @param {{isAccumulator:true, list:Array<string>, isFound:boolean, absolute:string, length:number,
+       *  append:function, placeholder:function, complete:function}} accumulator The accumulator
+       * @returns {{isAccumulator:true, list:Array<string>, isFound:boolean, absolute:string, length:number,
+       *  append:function, placeholder:function, complete:function}}
+       */
       function runIterator(accumulator) {
         var nextItem = iterator.next();
         var base     = !nextItem.done && nextItem.value;
-        if (typeof base === 'string') {
-          var element = predicate(filename, uri, base, accumulator.length, next);
+        var isValid  = (typeof base === 'string');
 
-          if ((typeof element === 'string') && path.isAbsolute(element)) {
-            return Object.assign(
-              accumulator.concat(base),
-              {isFound: true, absolute: element}
-            );
-          } else if (Array.isArray(element)) {
-            return element;
+        if (isValid) {
+          var pending       = predicate(filename, uri, base, accumulator.length, next, options);
+          var isPathString  = (typeof pending === 'string') && path.isAbsolute(pending),
+              isAccumulator = pending && (typeof pending === 'object') && pending.isAccumulator;
+
+          if (isPathString) {
+            // append happens here on success
+            return accumulator.append(base).complete(pending);
+          } else if (isAccumulator) {
+            // a next() was called internally to the predicate() giving the return value of the accumulator
+            return pending;
           } else {
             throw new Error('predicate must return an absolute path or the result of calling next()');
           }
         } else {
+          // iterator exhausted or badly formed
           return accumulator;
         }
 
-        function next(fallback) {
-          return runIterator(Object.assign(
-            accumulator.concat(base),
-            (typeof fallback === 'string') && {absolute: fallback}
-          ));
+        function next(value) {
+          // append happens here on failure
+          return runIterator(accumulator.append(base).placeholder(value));
         }
       }
     };
   }
 
   function toString() {
-    return '[Function: ' + name + ']';
+    return '[Function ' + name + ']';
   }
 
   return Object.assign(join, name && {
-    valueOf : toString,
-    toString: toString
+    toString: toString,
+    toJSON  : toString
   });
 }
 
-exports.createJoinForPredicate = createJoinForPredicate;
+exports.createJoinFunction = createJoinFunction;
+
+/**
+ * A utility to ensure the given value is an Iterator.
+ *
+ * Where an Array is given its value are filtered to be Unique and Truthy.
+ *
+ * @throws TypeError where not Array or Iterator
+ * @param {Array|Iterator} candidate The value to consider
+ * @returns {Iterator} An iterator
+ */
+function ensureIterator(candidate) {
+  if (Array.isArray(candidate)) {
+    return new Iterator(candidate.filter(isString).filter(isUnique));
+  } else if (candidate && (typeof candidate === 'object') && candidate[Symbol.iterator]) {
+    return candidate;
+  } else {
+    throw new TypeError('expected Array<string>|Iterator<string>');
+  }
+
+  function isString(v) {
+    return (typeof v === 'string');
+  }
+
+  function isUnique(v, i, a) {
+    return a.indexOf(v) === i;
+  }
+}
+
+exports.ensureIterator = ensureIterator;
 
 /**
  * Format a debug message.
  *
  * @param {string} file The file being processed by webpack
  * @param {string} uri A uri path, relative or absolute
- * @param {string[]} bases Absolute base paths up to and including the found one
- * @param {boolean} isFound Indicates the last base was correct
+ * @param {Array<string>} bases Absolute base paths up to and including the found one
+ * @param {boolean} isFound Indicates the last base was a positive match
  * @return {string} Formatted message
  */
 function createJoinMsg(file, uri, bases, isFound) {
@@ -176,7 +297,7 @@ function createDebugLogger(debug) {
   function noop() {}
 
   function actuallyLog(msgFn, params) {
-    var key = JSON.stringify(params);
+    var key = Function.prototype.toString.call(msgFn) + JSON.stringify(params);
     if (!cache[key]) {
       cache[key] = true;
       log(msgFn.apply(null, params));
@@ -185,3 +306,63 @@ function createDebugLogger(debug) {
 }
 
 exports.createDebugLogger = createDebugLogger;
+
+/**
+ * Create a fluent data type for accumulating data in the iterator.
+ * 
+ * Once complete the value is locked.
+ * 
+ * @param {{list:Array<string>, isFound:boolean, absolute:string}} context
+ * @returns {{isAccumulator:true, list:Array<string>, isFound:boolean, absolute:string, length:number,
+ *  append:function, placeholder:function, complete:function}}
+ */
+function createAccumulator(context) {
+  var self = {
+    get isAccumulator() {
+      return true;
+    },
+    get list() {
+      return context && context.list || [];
+    },
+    get isFound() {
+      return context && context.isFound || false;
+    },
+    get absolute() {
+      return context && context.absolute || null;
+    },
+    get length() {
+      return self.list.length;
+    },
+    append(value) {
+      return self.isFound ?
+        self :
+        createAccumulator({
+          list    : self.list.concat(value),
+          isFound : self.isFound,
+          absolute: self.absolute
+        });
+    },
+    placeholder(value) {
+      return self.isFound ?
+        self :
+        createAccumulator({
+          list    : self.list,
+          isFound : false,
+          absolute: value
+        });
+    },
+    complete(value) {
+      return self.isFound ?
+        self :
+        createAccumulator({
+          list    : self.list,
+          isFound : true,
+          absolute: value
+        });
+    }
+  };
+
+  return self;
+}
+
+exports.createAccumulator = createAccumulator;

--- a/packages/resolve-url-loader/lib/join-function.test.js
+++ b/packages/resolve-url-loader/lib/join-function.test.js
@@ -1,0 +1,327 @@
+/*
+ * MIT License http://opensource.org/licenses/MIT
+ * Author: Ben Holloway @bholloway
+ */
+'use strict';
+
+const {basename, resolve} = require('path');
+const tape = require('blue-tape');
+const sinon = require('sinon');
+const outdent = require('outdent');
+const Iterator = require('es6-iterator');
+
+const {
+  createJoinMsg, sanitiseIterable, createDebugLogger, createAccumulator, createJoinFunction
+} = require('./join-function');
+
+const json = (strings, ...substitutions) =>
+  String.raw(
+    strings,
+    ...substitutions.map(v => JSON.stringify(v, (_, vv) => Number.isNaN(vv) ? 'NaN' : vv))
+  );
+
+tape(
+  basename(require.resolve('./join-function')),
+  ({name, test, end: end1, equal, looseEqual, throws, doesNotThrow}) => {
+    test(`${name} / sanitiseIterable()`, ({end: end2}) => {
+      [
+        [['a', 1, 'b', 2, 'c'], ['a', 'b', 'c']],
+        [['x', 'y', 'z', 'x', 'y'], ['x', 'y', 'z']]
+      ].forEach(([input, expected]) => {
+        const result = sanitiseIterable(input);
+
+        equal(
+          result && typeof result === 'object' && typeof result[Symbol.iterator],
+          'function',
+          'Array input should create an Iterable output'
+        );
+
+        looseEqual(
+          [...result],
+          expected,
+          'Array should be permitted and filtered for unique strings'
+        );
+      });
+
+      [
+        [new Iterator(['a', 'b', 'c']), ['a', 'b', 'c']],
+        [new Iterator([1, 2, 3]), [1, 2, 3]],
+        [[1, 2, 3].keys(), [0, 1, 2]] // values() is unsupported until node v10.18.0
+      ].forEach(([input, expected]) =>
+        looseEqual(
+          [...sanitiseIterable(input)],
+          expected,
+          'Iterable should be permitted and unfiltered'
+        )
+      );
+
+      [
+        false,
+        123,
+        'hello',
+        {a:1, b:2}
+      ].forEach((input) =>
+        throws(
+          () => sanitiseIterable(input),
+          json`value ${input} should throw Error`
+        )
+      );
+
+      end2();
+    });
+
+    test(`${name} / createJoinMsg()`, ({end: end2}) => {
+      [
+        // absolute within cwd
+        [
+          [resolve('my-source-file.js'), 'my-asset.png', [resolve('foo'), resolve('bar', 'baz')], true],
+          outdent`
+            resolve-url-loader: ./my-source-file.js: my-asset.png
+              ./foo
+              ./bar/baz
+              FOUND
+              `
+        ],
+        // absolute otherwise
+        [
+          ['/my-source-file.js', '#anything\\./goes', ['/foo', '/bar/baz'], false],
+          outdent`
+            resolve-url-loader: /my-source-file.js: #anything\\./goes
+              /foo
+              /bar/baz
+              NOT FOUND
+              `
+        ],
+        // presumed relative
+        [
+          ['my-source-file.js', 'my-asset.png', ['foo', 'bar/baz'], true],
+          outdent`
+            resolve-url-loader: ./my-source-file.js: my-asset.png
+              ./foo
+              ./bar/baz
+              FOUND
+              `
+        ],
+        // explicitly relative
+        [
+          ['./my-source-file.js', 'my-asset.png', ['./foo', './bar/baz'], true],
+          outdent`
+            resolve-url-loader: ./my-source-file.js: my-asset.png
+              ./foo
+              ./bar/baz
+              FOUND
+              `
+        ],
+        [
+          ['../my-source-file.js', 'my-asset.png', ['../foo', '../bar/baz'], false],
+          outdent`
+            resolve-url-loader: ../my-source-file.js: my-asset.png
+              ../foo
+              ../bar/baz
+              NOT FOUND
+              `
+        ],
+        // empty
+        [
+          ['./my-source-file.js', 'my-asset.png', [''], true],
+          outdent`
+            resolve-url-loader: ./my-source-file.js: my-asset.png
+              -empty-
+              FOUND
+              `
+        ],
+      ].forEach(([input, expected]) =>
+        equal(
+          createJoinMsg(...input),
+          expected,
+          json`input ${input} should sanitise to ${expected}`
+        )
+      );
+
+      end2();
+    });
+
+    test(`${name} / createDebugLogger()`, ({name: name2, test: test2, end: end2}) => {
+      test2(`${name2} / false`, ({end: end3}) => {
+        const sandbox = sinon.createSandbox();
+        const factory = sandbox.fake.returns('foo');
+        const consoleLog = sandbox.stub(console, 'log');
+
+        const logger = createDebugLogger(false);
+        logger(factory);
+        sandbox.restore();
+
+        equal(consoleLog.callCount, 0, 'should not call console.log()');
+        equal(factory.callCount, 0, 'should not call underlying message factory');
+
+        end3();
+      });
+
+      test2(`${name2} / true`, ({end: end3}) => {
+        const sandbox = sinon.createSandbox();
+        const factory = sandbox.fake.returns('foo');
+        const consoleLog = sandbox.stub(console, 'log');
+
+        const logger = createDebugLogger(true);
+        logger(factory, ['bar', 1, false]);
+        logger(factory, ['baz', 2, undefined]);
+        sandbox.restore();
+
+        equal(factory.callCount, 2, 'should call underlying log message factory');
+        looseEqual(
+          factory.args,
+          [['bar', 1, false], ['baz', 2, undefined]],
+          'should call underlying message factory with expected arguments'
+        );
+
+        equal(consoleLog.callCount, 2, 'should call console.log()');
+        looseEqual(
+          consoleLog.args,
+          [['foo'], ['foo']],
+          'should log expected value'
+        );
+
+        end3();
+      });
+
+      test2(`${name2} / logFn`, ({end: end3}) => {
+        const sandbox = sinon.createSandbox();
+        const factory = sandbox.fake.returns('foo');
+        const consoleLog = sandbox.stub(console, 'log');
+        const logFn = sandbox.spy();
+
+        const logger = createDebugLogger(logFn);
+        logger(factory, ['bar', 1, false]);
+        logger(factory, ['baz', 2, undefined]);
+        sandbox.restore();
+
+        equal(factory.callCount, 2, 'should call underlying log message factory');
+        looseEqual(
+          factory.args,
+          [['bar', 1, false], ['baz', 2, undefined]],
+          'should call underlying message factory with expected arguments'
+        );
+
+        equal(logFn.callCount, 2, 'should call logFn()');
+        looseEqual(
+          logFn.args,
+          [['foo'], ['foo']],
+          'should log expected value'
+        );
+
+        equal(consoleLog.callCount, 0, 'should not call console.log()');
+
+        end3();
+      });
+
+      end2();
+    });
+
+    test(`${name} / createAccumulator()`, ({end: end2}) => {
+      const sanitise = object => Object.entries(object)
+        .reduce((r, [k, v]) => typeof v === 'function' ? r : Object.assign(r, {[k]: v}), {});
+
+      const initial = createAccumulator();
+      looseEqual(
+        sanitise(initial),
+        {isAccumulator: true, list: [], length: 0, absolute: null, isFound:false},
+        'initial state should be as expected'
+      );
+
+      [
+        ['append', 'a', {isAccumulator: true, list: ['a'], length: 1, absolute: null, isFound:false}],
+        ['append', 'b', {isAccumulator: true, list: ['a', 'b'], length: 2, absolute: null, isFound:false}],
+        ['placeholder', 'foo', {isAccumulator: true, list: ['a', 'b'], length: 2, absolute: 'foo', isFound:false}],
+        ['placeholder', 'bar', {isAccumulator: true, list: ['a', 'b'], length: 2, absolute: 'bar', isFound:false}],
+        ['append', 'c', {isAccumulator: true, list: ['a', 'b', 'c'], length: 3, absolute: 'bar', isFound:false}],
+        ['found', 'baz', {isAccumulator: true, list: ['a', 'b', 'c'], length: 3, absolute: 'baz', isFound:true}],
+        ['append', 'd', null],
+        ['placeholder', 'foo', null],
+        ['found', 'blit', null],
+      ].reduce((sut, [op, value, expected]) => {
+        const last = sanitise(sut);
+        const result = sut[op](value);
+
+        looseEqual(sanitise(sut), last, `${op}() should be immutable`);
+        if (expected) {
+          looseEqual(sanitise(result), expected, `${op}() should behave as expected`);
+        } else {
+          looseEqual(sanitise(result), last, `${op}() should not operate on finalised instance`);
+        }
+
+        return result;
+      }, initial);
+
+      end2();
+    });
+
+    test(`${name} / createJoinFunction()`, ({name: name2, test: test2, end: end2}) => {
+      const sandbox = sinon.createSandbox();
+
+      const setup = () => {
+        const joinFn = sandbox.stub();
+        const predicateFn = sandbox.stub();
+        const logFn = sandbox.spy();
+
+        const sut = createJoinFunction('foo', joinFn, predicateFn)('my-source-file.js', {debug: logFn});
+
+        return {sut, joinFn, predicateFn, logFn};
+      };
+
+      test2(`${name2} / factoryFn`, ({end: end3}) => {
+        const {sut, joinFn, predicateFn} = setup();
+        joinFn.returns(['a', 'b', 'c']);
+        predicateFn.returns(resolve('bar'));
+
+        sut('my-asset.png', ['baz', 'blit']);
+        looseEqual(
+          joinFn.args[0].slice(0, 2),
+          ['my-source-file.js', ['baz', 'blit']],
+          'should be called with expected arguments'
+        );
+
+        end3();
+      });
+
+      test2(`${name2} / predicateFn`, ({end: end3}) => {
+        const {sut, joinFn, predicateFn} = setup();
+        joinFn.returns(['a', 'b', 'c']);
+        predicateFn.callsFake((_filename, _uri, _base, i, next) => i === 0 ? next() : resolve('bar'));
+
+        sut('my-asset.png', ['baz', 'blit']);
+        looseEqual(
+          predicateFn.args.map((v) => v.slice(0, 4)),
+          [['my-source-file.js', 'my-asset.png', 'a', 0], ['my-source-file.js', 'my-asset.png', 'b', 1]],
+          'should be called with expected arguments'
+        );
+
+        [
+          [resolve('bar'), true],
+          ['bar', false],
+          ['#bar', false],
+          ['~bar', false],
+          ['~/bar', false]
+        ].forEach(([input, isValid]) => {
+          const test = () => sut('my-asset.png', ['baz', 'blit']);
+          predicateFn.returns(input);
+          if (isValid) {
+            doesNotThrow(test, json`should not throw on output ${input}`);
+          } else {
+            throws(
+              () => sut('my-asset.png', ['baz', 'blit']),
+              json`should throw on output ${input}`
+            );
+          }
+        });
+
+        end3();
+      });
+
+
+
+      end2();
+    });
+
+    end1();
+  }
+);

--- a/packages/resolve-url-loader/lib/log-to-test-harness.js
+++ b/packages/resolve-url-loader/lib/log-to-test-harness.js
@@ -6,20 +6,30 @@
 
 var stream = require('stream');
 
-var maybeStream = process[process.env.RESOLVE_URL_LOADER_TEST_HARNESS];
+var hasLogged = false;
 
-function logToTestHarness(options) {
-  if (!!maybeStream && (typeof maybeStream === 'object') && (maybeStream instanceof stream.Writable)) {
-    Object.keys(options).map(eachOptionKey);
-    maybeStream = null; // ensure we log only once
+function logToTestHarness(maybeStream, options) {
+  var doLogging =
+    !hasLogged &&
+    !!maybeStream &&
+    (typeof maybeStream === 'object') &&
+    (maybeStream instanceof stream.Writable);
+
+  if (doLogging) {
+    hasLogged = true; // ensure we log only once
+    Object.keys(options).forEach(eachOptionKey);
   }
 
   function eachOptionKey(key) {
-    var value = options[key];
-    var text  = (typeof value === 'undefined') ?
-      String(value) :
-      (JSON.stringify(value.valueOf()) || '-unstringifyable-');
-    maybeStream.write(key + ': ' + text + '\n');
+    maybeStream.write(key + ': ' + stringify(options[key]) + '\n');
+  }
+
+  function stringify(value) {
+    try {
+      return JSON.stringify(value) || String(value);
+    } catch (e) {
+      return '-unstringifyable-';
+    }
   }
 }
 

--- a/packages/resolve-url-loader/lib/value-processor.js
+++ b/packages/resolve-url-loader/lib/value-processor.js
@@ -5,14 +5,13 @@
 'use strict';
 
 var path        = require('path'),
-    loaderUtils = require('loader-utils'),
-    Iterator    = require('es6-iterator');
+    loaderUtils = require('loader-utils');
 
 /**
  * Create a value processing function for a given file path.
  *
  * @param {string} filename The current file being processed
- * @param {{join:function, root:string}} options Options hash
+ * @param {{fs:Object, debug:function|boolean, join:function, root:string}} options Options hash
  * @return {function} value processing function
  */
 function valueProcessor(filename, options) {
@@ -26,7 +25,7 @@ function valueProcessor(filename, options) {
    * Process the given CSS declaration value.
    *
    * @param {string} value A declaration value that may or may not contain a url() statement
-   * @param {function(number|number[]):string[]} getPathsAtChar Given an offset in the declaration value get a
+   * @param {function(number):Object} getPathsAtChar Given an offset in the declaration value get a
    *  list of possible absolute path strings
    */
   return function transformValue(value, getPathsAtChar) {
@@ -89,8 +88,8 @@ function valueProcessor(filename, options) {
         var split    = unescaped.split(QUERY_REGEX),
             uri      = split[0],
             query    = split.slice(1).join(''),
-            absolute = testIsRelative(uri) && join(uri, new Iterator(getPathsAtChar(position))) ||
-                       testIsAbsolute(uri) && join(uri);
+            absolute = testIsRelative(uri) && join(uri, getPathsAtChar(position)) ||
+                       testIsAbsolute(uri) && join(uri, null);
 
         // default to initialised else path relative to the processed file
         if (!absolute) {

--- a/packages/resolve-url-loader/package.json
+++ b/packages/resolve-url-loader/package.json
@@ -40,6 +40,7 @@
     "compose-function": "3.0.3",
     "convert-source-map": "1.7.0",
     "es6-iterator": "2.0.3",
+    "es6-symbol": "^3.1.1",
     "loader-utils": "1.2.3",
     "postcss": "7.0.21",
     "rework": "1.0.1",

--- a/test/cases/absolute-asset.js
+++ b/test/cases/absolute-asset.js
@@ -19,6 +19,7 @@ const {
 
 const assertDebugMessages = assertStdout('debug')(1)`
   ^resolve-url-loader:[^:]+:[ ]+${process.cwd()}.*${join('images', 'img.jpg')}
+  [ ]+-empty-
   [ ]+FOUND$
   `;
 

--- a/test/cases/common/test/invalid.js
+++ b/test/cases/common/test/invalid.js
@@ -93,7 +93,7 @@ exports.testWrongArityJoin = (...rest) =>
         OUTPUT: 'wrong-arity-join'
       }),
       ...rest,
-      test('validate', assertStderr('options.join')(1)`join: -unstringifyable-`)
+      test('validate', assertStderr('options.join')(1)`join: \(a\) => a`)
     )
   );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,35 @@
 # yarn lockfile v1
 
 
+"@sinonjs/commons@^1", "@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.0.tgz#f90ffc52a2e519f018b13b6c4da03cbff36ebed6"
+  integrity sha512-qbk9AP+cZUsKdW1GJsBpxPKFmCJ0T8swwzVje3qFd+AkQb74Q/tiuzrdfFg8AD2g5HH/XbE/I8Uc1KYHVYWfhg==
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/formatio@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-4.0.1.tgz#50ac1da0c3eaea117ca258b06f4f88a471668bdb"
+  integrity sha512-asIdlLFrla/WZybhm0C8eEzaDNNrzymiTqHMeJl6zPW2881l3uuVRpm0QlRQEjqYWv6CcKMGYME3LbrLJsORBw==
+  dependencies:
+    "@sinonjs/commons" "^1"
+    "@sinonjs/samsam" "^4.2.0"
+
+"@sinonjs/samsam@^4.2.0", "@sinonjs/samsam@^4.2.1":
+  version "4.2.1"
+  resolved "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-4.2.1.tgz#cee77dc95f8d00339633e1683e026f2d73ed1d3a"
+  integrity sha512-7+5S4C4wpug5pzHS+z/63+XUwsH7dtyYELDafoT1QnfruFh7eFjlDWwZXltUB0GLk6y5eMeAt34Bjx8wJ4KfSA==
+  dependencies:
+    "@sinonjs/commons" "^1.6.0"
+    lodash.get "^4.4.2"
+    type-detect "^4.0.8"
+
+"@sinonjs/text-encoding@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
+  integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
+
 adjust-sourcemap-loader@2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/adjust-sourcemap-loader/-/adjust-sourcemap-loader-2.0.0.tgz#6471143af75ec02334b219f54bc7970c52fb29a4"
@@ -384,6 +413,11 @@ diff@^2.2.1:
   resolved "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz#60eafd0d28ee906e4e8ff0a52c1229521033bf99"
   integrity sha1-YOr9DSjukG5Oj/ClLBIpUhAzv5k=
 
+diff@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz#0c667cb467ebbb5cea7f14f135cc2dba7780a8ff"
+  integrity sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==
+
 dom-serializer@0:
   version "0.2.1"
   resolved "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.1.tgz#13650c850daffea35d8b626a4cfc4d3a17643fdb"
@@ -644,6 +678,11 @@ has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
   integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
+
+has-flag@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
+  integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
 has-prop@0.1.2:
   version "0.1.2"
@@ -933,6 +972,11 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
+just-extend@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz#f3f47f7dfca0f989c55410a7ebc8854b07108afc"
+  integrity sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==
+
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
@@ -971,10 +1015,22 @@ lodash.clonedeep@4.5.0:
   resolved "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
   integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
 
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
+
 lodash@~4.17.11:
   version "4.17.15"
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
+lolex@^5.0.1, lolex@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz#953694d098ce7c07bc5ed6d0e42bc6c0c6d5a367"
+  integrity sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==
+  dependencies:
+    "@sinonjs/commons" "^1.7.0"
 
 map-cache@^0.2.2:
   version "0.2.2"
@@ -1080,6 +1136,18 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
+nise@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.npmjs.org/nise/-/nise-3.0.1.tgz#0659982af515e5aac15592226246243e8da0013d"
+  integrity sha512-fYcH9y0drBGSoi88kvhpbZEsenX58Yr+wOJ4/Mi1K4cy+iGP/a73gNoyNhu5E9QxPdgTlVChfIaAlnyOy/gHUA==
+  dependencies:
+    "@sinonjs/commons" "^1.7.0"
+    "@sinonjs/formatio" "^4.0.1"
+    "@sinonjs/text-encoding" "^0.7.1"
+    just-extend "^4.0.2"
+    lolex "^5.0.1"
+    path-to-regexp "^1.7.0"
 
 number-is-nan@^1.0.0:
   version "1.0.1"
@@ -1200,6 +1268,13 @@ path-parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
+
+path-to-regexp@^1.7.0:
+  version "1.8.0"
+  resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
+  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
+  dependencies:
+    isarray "0.0.1"
 
 plur@^1.0.0:
   version "1.0.0"
@@ -1385,6 +1460,19 @@ shelljs@0.3.x:
   resolved "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz#3596e6307a781544f591f37da618360f31db57b1"
   integrity sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=
 
+sinon@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.npmjs.org/sinon/-/sinon-8.0.2.tgz#cc5f6daa9cc351b86b03faaca1e9c3650a04ae11"
+  integrity sha512-8W1S7BnCyvk7SK+Xi15B1QAVLuS81G/NGmWefPb31+ly6xI3fXaug/g5oUdfc8+7ruC4Ay51AxuLlYm8diq6kA==
+  dependencies:
+    "@sinonjs/commons" "^1.7.0"
+    "@sinonjs/formatio" "^4.0.1"
+    "@sinonjs/samsam" "^4.2.1"
+    diff "^4.0.1"
+    lolex "^5.1.2"
+    nise "^3.0.1"
+    supports-color "^7.1.0"
+
 snapdragon-node@^2.0.1:
   version "2.1.1"
   resolved "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
@@ -1547,6 +1635,13 @@ supports-color@^6.1.0:
   dependencies:
     has-flag "^3.0.0"
 
+supports-color@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz#68e32591df73e25ad1c4b49108a2ec507962bfd1"
+  integrity sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==
+  dependencies:
+    has-flag "^4.0.0"
+
 tap-diff@0.1.1:
   version "0.1.1"
   resolved "https://registry.npmjs.org/tap-diff/-/tap-diff-0.1.1.tgz#8fbf3333d85643feea1bf1759b90820b04a37ddf"
@@ -1634,6 +1729,11 @@ topo@3.x.x:
   integrity sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==
   dependencies:
     hoek "6.x.x"
+
+type-detect@4.0.8, type-detect@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
+  integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
 type@^1.0.1:
   version "1.2.0"


### PR DESCRIPTION
## concept

The aim is to produce a `factory` which orders the possible base directories and a `predicate` which tests the base directories. The separation of concerns should make it easier to order or possible base directories without changing the predicate.

The `factory` is given the possible `bases` as hash. So it can arbitrarily set the precedence of `subString`, `value`, `property`, `selector` source-map locations and return `Array<string>`.

The `factory` should be lazy since it might traverse the file-system search in order to suggest base paths. In that case we would want to abort if the `predicate` matches. It can optionally return `Iterator<string>`.

The `predicate` is largely unchanged. However it now uses `fs` from Webpack. This should solve any lingering issues we webpack-dev-server (untested).

## changes
- [x] refactor join for separate `factory` and `predicate`
- [x] provide a hash of bases to `factory` to allow explicit ordering of precedence
- [x] adapt `predicate` to use `loader.fs`
- [ ] ? provide some sort utility method for file-system search (@runfaj)
- [x] ? unit tests for `join-function.js`

## examples

Considering the example given by @MightyPork in [this comment](https://github.com/bholloway/resolve-url-loader/issues/129#issuecomment-542160339).

We can now add a fallback theme directory with minimum code.

```javascript
const compose = require('compose-function');
const {
  createJoinFunction,
  defaultJoinFactory,
  defaultJoinPredicate
} = require('resolve-url-loader');

const appendThemeDirectory = (list) =>
  list.concat(path.join(__dirname, 'resources', 'assets', 'sass', 'theme'));

const customJoin = createJoinFunction(
  'customJoin',
  compose(appendThemeDirectory, defaultJoinFactory),
  defaultJoinPredicate
);
``` 
