### PR TITLE
Drop symbol polyfill

### DIFF
--- a/packages/resolve-url-loader/lib/join-function.js
+++ b/packages/resolve-url-loader/lib/join-function.js
@@ -5,8 +5,7 @@
 'use strict';
 
 var path     = require('path'),
-    Iterator = require('es6-iterator'),
-    Symbol   = require('es6-symbol');
+    Iterator = require('es6-iterator');
 
 var PACKAGE_NAME = require('../package.json').name;
 

--- a/packages/resolve-url-loader/package.json
+++ b/packages/resolve-url-loader/package.json
@@ -39,7 +39,6 @@
     "adjust-sourcemap-loader": "2.0.0",
     "convert-source-map": "1.7.0",
     "es6-iterator": "2.0.3",
-    "es6-symbol": "^3.1.1",
     "loader-utils": "1.2.3",
     "postcss": "7.0.21",
     "rework": "1.0.1",


### PR DESCRIPTION
Ref https://node.green/#ES2015-built-ins-well-known-symbols-Symbol-iterator--existence

Symbol is supported in node since v6. There is no need to polyfill it.