### PR TITLE
Drop symbol and iterator polyfills

### DIFF
--- a/packages/resolve-url-loader/lib/join-function.js
+++ b/packages/resolve-url-loader/lib/join-function.js
@@ -4,9 +4,7 @@
  */
 'use strict';
 
-var path     = require('path'),
-    Iterator = require('es6-iterator'),
-    Symbol   = require('es6-symbol');
+var path = require('path');
 
 var PACKAGE_NAME = require('../package.json').name;
 
@@ -218,7 +216,7 @@ exports.createJoinFunction = createJoinFunction;
  */
 function sanitiseIterable(candidate) {
   if (Array.isArray(candidate)) {
-    return new Iterator(candidate.filter(isString).filter(isUnique));
+    return candidate.filter(isString).filter(isUnique)[Symbol.iterator]();
   } else if (candidate && (typeof candidate === 'object') && candidate[Symbol.iterator]) {
     return candidate;
   } else {

--- a/packages/resolve-url-loader/lib/join-function.test.js
+++ b/packages/resolve-url-loader/lib/join-function.test.js
@@ -8,7 +8,6 @@ const {basename, resolve} = require('path');
 const tape = require('blue-tape');
 const sinon = require('sinon');
 const outdent = require('outdent');
-const Iterator = require('es6-iterator');
 
 const {
   createJoinMsg, sanitiseIterable, createDebugLogger, createAccumulator, createJoinFunction
@@ -44,8 +43,8 @@ tape(
       });
 
       [
-        [new Iterator(['a', 'b', 'c']), ['a', 'b', 'c']],
-        [new Iterator([1, 2, 3]), [1, 2, 3]],
+        [['a', 'b', 'c'][Symbol.iterator](), ['a', 'b', 'c']],
+        [[1, 2, 3][Symbol.iterator](), [1, 2, 3]],
         [[1, 2, 3].keys(), [0, 1, 2]] // values() is unsupported until node v10.18.0
       ].forEach(([input, expected]) =>
         looseEqual(

--- a/packages/resolve-url-loader/package.json
+++ b/packages/resolve-url-loader/package.json
@@ -38,8 +38,6 @@
   "dependencies": {
     "adjust-sourcemap-loader": "2.0.0",
     "convert-source-map": "1.7.0",
-    "es6-iterator": "2.0.3",
-    "es6-symbol": "^3.1.1",
     "loader-utils": "1.2.3",
     "postcss": "7.0.21",
     "rework": "1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -339,14 +339,6 @@ css@^2.0.0:
     source-map-resolve "^0.5.2"
     urix "^0.1.0"
 
-d@1, d@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/d/-/d-1.0.1.tgz#8698095372d58dbee346ffd0c7093f99f8f9eb5a"
-  integrity sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==
-  dependencies:
-    es5-ext "^0.10.50"
-    type "^1.0.1"
-
 date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
@@ -496,36 +488,10 @@ es-to-primitive@^1.2.0:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-es5-ext@^0.10.35, es5-ext@^0.10.50:
-  version "0.10.52"
-  resolved "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.52.tgz#bb21777e919a04263736ded120a9d665f10ea63f"
-  integrity sha512-bWCbE9fbpYQY4CU6hJbJ1vSz70EClMlDgJ7BmwI+zEJhxrwjesZRPglGJlsZhu0334U3hI+gaspwksH9IGD6ag==
-  dependencies:
-    es6-iterator "~2.0.3"
-    es6-symbol "~3.1.2"
-    next-tick "~1.0.0"
-
-es6-iterator@2.0.3, es6-iterator@~2.0.3:
-  version "2.0.3"
-  resolved "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
-  integrity sha1-p96IkUGgWpSwhUQDstCg+/qY87c=
-  dependencies:
-    d "1"
-    es5-ext "^0.10.35"
-    es6-symbol "^3.1.1"
-
 es6-promisify@6.0.2:
   version "6.0.2"
   resolved "https://registry.npmjs.org/es6-promisify/-/es6-promisify-6.0.2.tgz#525c23725b8510f5f1f2feb5a1fbad93a93e29b4"
   integrity sha512-eO6vFm0JvqGzjWIQA6QVKjxpmELfhWbDUWHm1rPfIbn55mhKPiAa5xpLmQWJrNa629ZIeQ8ZvMAi13kvrjK6Mg==
-
-es6-symbol@^3.1.1, es6-symbol@~3.1.2:
-  version "3.1.3"
-  resolved "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz#bad5d3c1bcdac28269f4cb331e431c78ac705d18"
-  integrity sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==
-  dependencies:
-    d "^1.0.1"
-    ext "^1.1.2"
 
 escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -559,13 +525,6 @@ expand-brackets@^2.1.4:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
-
-ext@^1.1.2:
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/ext/-/ext-1.2.0.tgz#8dd8d2dd21bcced3045be09621fa0cbf73908ba4"
-  integrity sha512-0ccUQK/9e3NreLFg6K6np8aPyRgwycx+oFGtfx1dSp7Wj00Ozw9r05FgBRlzjf2XBM7LAzwgLyDscRrtSU91hA==
-  dependencies:
-    type "^2.0.0"
 
 extend-shallow@^2.0.1:
   version "2.0.1"
@@ -1126,11 +1085,6 @@ nanomatch@^1.2.9:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
-
-next-tick@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
-  integrity sha1-yobR/ogoFpsBICCOPchCS524NCw=
 
 nice-try@^1.0.4:
   version "1.0.5"
@@ -1734,16 +1688,6 @@ type-detect@4.0.8, type-detect@^4.0.8:
   version "4.0.8"
   resolved "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
-
-type@^1.0.1:
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/type/-/type-1.2.0.tgz#848dd7698dafa3e54a6c479e759c4bc3f18847a0"
-  integrity sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==
-
-type@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/type/-/type-2.0.0.tgz#5f16ff6ef2eb44f260494dae271033b29c09a9c3"
-  integrity sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==
 
 union-value@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Symbol is supported in node since v6. There is no need to polyfill it. (Ref https://node.green/#ES2015-built-ins-well-known-symbols-Symbol-iterator--existence)

Array iterator is supported even longer. (https://node.green/#ES2015-built-in-extensions-Array-prototype-methods-Array-prototype-Symbol-iterator-)

Both quite big dependencies can be removed.

https://packagephobia.com/result?p=es6-iterator