### PR TITLE
Rework as optional peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "outdent": "^0.7.0",
     "promise-compose": "^1.1.2",
     "recursive-readdir": "^2.2.2",
+    "rework": "1.0.1",
+    "rework-visit": "1.0.0",
     "sinon": "^8.0.2",
     "tap-diff": "^0.1.1",
     "vlq": "^1.0.1"

--- a/packages/resolve-url-loader/README.md
+++ b/packages/resolve-url-loader/README.md
@@ -198,7 +198,7 @@ If you have _any_ such multiline declarations preceding `url()` statements it wi
 Libsass doesn't consider these orphan `CR` to be newlines but `postcss` engine does.  The result being an offset in source-map line-numbers which crashes `resolve-url-loader`.
 
 ```
-Module build failed: Error: resolve-url-loader: CSS error
+Module build failed: Error: resolve-url-loader: error processing CSS
   source-map information is not available at url() declaration
 ```
 

--- a/packages/resolve-url-loader/README.md
+++ b/packages/resolve-url-loader/README.md
@@ -37,6 +37,7 @@ In our example it rewrites `url(bar.png)` to `url(features/bar.png)` as required
 **Features**
 
 * Better resolution of the original source location - You can more successfully use `url()` in variables and mixins.
+* Dependencies now accept a wider range and the dependency on `rework` and `rework-visit` has been removed.
 
 **Breaking Changes**
 
@@ -46,11 +47,13 @@ In our example it rewrites `url(bar.png)` to `url(features/bar.png)` as required
 
 **Migrating**
 
-Remove the `engine` option if you are using it - the default "postcss" engine is much more reliable. The "rework" engine will still work for now but it will be removed in the next major version.
+Remove the `engine` option if you are using it - the default "postcss" engine is much more reliable. The "rework" engine will still work for now but will be removed in the next major version.
 
 Remove the `keepQuery` option if you are using it.
 
 Remove the `absolute` option, webpack should work fine without it. If you have a specific need to rebase `url()` then you should use a separate loader.
+
+If you wish to still use `engine: "rework"` then note that `rework` and `rework-visit` packages are now `peerDependencies` that must be explicitly installed by you.
 
 ## Version 3
 

--- a/packages/resolve-url-loader/index.js
+++ b/packages/resolve-url-loader/index.js
@@ -172,7 +172,7 @@ function resolveUrlLoader(content, sourceMap) {
   }
 
   // choose a CSS engine
-  var enginePath    = /^\w+$/.test(options.engine) && path.join(__dirname, 'lib', 'engine', options.engine + '.js');
+  var enginePath    = /^[\w-]+$/.test(options.engine) && path.join(__dirname, 'lib', 'engine', options.engine + '.js');
   var isValidEngine = fs.existsSync(enginePath);
   if (!isValidEngine) {
     return handleAsError(

--- a/packages/resolve-url-loader/index.js
+++ b/packages/resolve-url-loader/index.js
@@ -181,10 +181,21 @@ function resolveUrlLoader(content, sourceMap) {
     );
   }
 
+  // allow engine to throw at initialisation
+  var engine;
+  try {
+    engine = require(enginePath);
+  } catch (error) {
+    return handleAsError(
+      'error initialising',
+      error
+    );
+  }
+
   // process async
   var callback = loader.async();
   Promise
-    .resolve(require(enginePath)(loader.resourcePath, content, {
+    .resolve(engine(loader.resourcePath, content, {
       outputSourceMap     : !!options.sourceMap,
       transformDeclaration: valueProcessor(loader.resourcePath, options),
       absSourceMap        : absSourceMap,
@@ -195,7 +206,7 @@ function resolveUrlLoader(content, sourceMap) {
     .then(onSuccess);
 
   function onFailure(error) {
-    callback(encodeError('CSS error', error));
+    callback(encodeError('error processing CSS', error));
   }
 
   function onSuccess(result) {

--- a/packages/resolve-url-loader/lib/engine/fail-initialisation.js
+++ b/packages/resolve-url-loader/lib/engine/fail-initialisation.js
@@ -1,0 +1,7 @@
+/*
+ * MIT License http://opensource.org/licenses/MIT
+ * Author: Ben Holloway @bholloway
+ */
+'use strict';
+
+throw new Error('This "engine" is designed to fail at require time, for testing purposes only');

--- a/packages/resolve-url-loader/lib/engine/fail-processing.js
+++ b/packages/resolve-url-loader/lib/engine/fail-processing.js
@@ -10,7 +10,7 @@
 function process() {
   return new Promise(function (_, reject) {
     setTimeout(function () {
-      reject(new Error('This "engine" is designed to fail, for testing purposes only'));
+      reject(new Error('This "engine" is designed to fail at processing time, for testing purposes only'));
     }, 100);
   });
 }

--- a/packages/resolve-url-loader/lib/engine/rework.js
+++ b/packages/resolve-url-loader/lib/engine/rework.js
@@ -5,11 +5,12 @@
 'use strict';
 
 var path    = require('path'),
-    convert = require('convert-source-map'),
-    rework  = require('rework'),
-    visit   = require('rework-visit');
+    convert = require('convert-source-map');
 
 var fileProtocol = require('../file-protocol');
+
+var rework = requireOptionalPeerDependency('rework'),
+    visit  = requireOptionalPeerDependency('rework-visit');
 
 /**
  * Process the given CSS content into reworked CSS content.
@@ -131,3 +132,24 @@ function process(sourceFile, sourceContent, params) {
 }
 
 module.exports = process;
+
+/**
+ * Require the given filename but fail with an error that `requireOptionalPeerDependencies` must be installed.
+ *
+ * @param moduleName The module to require
+ * @returns {*} The module
+ * @throws Error when module is not found
+ */
+function requireOptionalPeerDependency(moduleName) {
+  try {
+    return require(moduleName);
+  }
+  catch (error) {
+    if (error.message === 'Cannot find module \'' + moduleName + '\'') {
+      throw new Error('To use the "rework" engine you must install the optionalPeerDependencies');
+    }
+    else {
+      throw error;
+    }
+  }
+}

--- a/packages/resolve-url-loader/package.json
+++ b/packages/resolve-url-loader/package.json
@@ -40,8 +40,18 @@
     "convert-source-map": "^1.7.0",
     "loader-utils": "^1.4.0",
     "postcss": "^7.0.32",
-    "rework": "1.0.1",
-    "rework-visit": "1.0.0",
     "source-map": "0.6.1"
+  },
+  "peerDependencies": {
+    "rework": "1.0.1",
+    "rework-visit": "1.0.0"
+  },
+  "peerDependenciesMeta": {
+    "rework": {
+      "optional": true
+    },
+    "rework-visit": {
+      "optional": true
+    }
   }
 }

--- a/test/cases/common/test/invalid.js
+++ b/test/cases/common/test/invalid.js
@@ -136,15 +136,28 @@ exports.testSilent = (...rest) =>
     )
   );
 
-exports.testEngineFail = (...rest) =>
+exports.testEngineFailInitialisation = (...rest) =>
   test(
-    'engine=fail',
+    'engine=fail-initialisation',
     layer()(
       env({
-        LOADER_OPTIONS: {engine: 'fail'},
-        OUTPUT: 'engine-fail'
+        LOADER_OPTIONS: {engine: 'fail-initialisation'},
+        OUTPUT: 'engine-fail-initialisation'
       }),
       ...rest,
-      test('validate', assertStderr('options.engine')(1)`engine: "fail"`)
+      test('validate', assertStderr('options.engine')(1)`engine: "fail-initialisation"`)
+    )
+  );
+
+exports.testEngineFailProcessing = (...rest) =>
+  test(
+    'engine=fail-processing',
+    layer()(
+      env({
+        LOADER_OPTIONS: {engine: 'fail-processing'},
+        OUTPUT: 'engine-fail-processing'
+      }),
+      ...rest,
+      test('validate', assertStderr('options.engine')(1)`engine: "fail-processing"`)
     )
   );

--- a/test/cases/orphan-carriage-return.postcss.js
+++ b/test/cases/orphan-carriage-return.postcss.js
@@ -29,7 +29,7 @@ const assertDebugMessages = assertStdout('debug')(1)`
 //  - webpack may repeat errors with a header line taken from the parent loader
 const assertCssError = assertStdout('error')([1, 4])`
   ^[ ]*ERROR[^\n]*
-  ([^\n]+\n){0,2}[^\n]*resolve-url-loader:[ ]*CSS error
+  ([^\n]+\n){0,2}[^\n]*resolve-url-loader:[ ]*error processing CSS
   [ ]+source-map information is not available at url\(\) declaration \(found orphan CR, try removeCR option\)
   `;
 


### PR DESCRIPTION
As suggested in #160.

Seems that this works fine except that it doesn't really _do_ anything. I would expect there to be a warning if the installed dependency version did not match.

For example, if I have `rework@0.20.3` installed instead of the required `rework@1.0.1` then I would expect that mismatch to have a warning.

- [x] Tested MacOS
- [x] Tested Windows 10