### PR TITLE
Bump PostCSS

### DIFF
--- a/packages/resolve-url-loader/package.json
+++ b/packages/resolve-url-loader/package.json
@@ -43,7 +43,7 @@
     "convert-source-map": "1.7.0",
     "es6-iterator": "2.0.3",
     "loader-utils": "1.2.3",
-    "postcss": "7.0.21",
+    "postcss": "7.0.36",
     "rework": "1.0.1",
     "rework-visit": "1.0.0",
     "source-map": "0.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1162,10 +1162,10 @@ posix-character-classes@^0.1.0:
   resolved "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
 
-postcss@7.0.21:
-  version "7.0.21"
-  resolved "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz#06bb07824c19c2021c5d056d5b10c35b989f7e17"
-  integrity sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==
+postcss@7.0.36:
+  version "7.0.36"
+  resolved "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz#056f8cffa939662a8f5905950c07d5285644dfcb"
+  integrity sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==
   dependencies:
     chalk "^2.4.2"
     source-map "^0.6.1"


### PR DESCRIPTION
Hello 👋🏻 

I stumbled across your package because it's a dependency of `react-scripts`. Unfortunately, it pins PostCSS to a version that turned out to be vulnerable, see https://www.npmjs.com/advisories/1693

I'd like to propose to bump to the latest bugfix release of PostCSS which contains a patch against that vulnerability.