### PR TITLE
Update Loader Utils to 2.0.4 to fix a vulnerability in v5

### DIFF
--- a/packages/resolve-url-loader/package.json
+++ b/packages/resolve-url-loader/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "adjust-sourcemap-loader": "^4.0.0",
     "convert-source-map": "^1.7.0",
-    "loader-utils": "^2.0.0",
+    "loader-utils": "^2.0.4",
     "postcss": "^8.2.14",
     "source-map": "0.6.1"
   }


### PR DESCRIPTION
Fixes https://github.com/bholloway/resolve-url-loader/issues/226 in v5 (the version used by Angular 14.X)
(doesn't require an update to 3.0 like the issues mentions)