### PR TITLE
V3 maintenance: loosen constraints on `loader-utils` dependency

### DIFF
--- a/packages/resolve-url-loader/package.json
+++ b/packages/resolve-url-loader/package.json
@@ -42,7 +42,7 @@
     "compose-function": "3.0.3",
     "convert-source-map": "1.7.0",
     "es6-iterator": "2.0.3",
-    "loader-utils": "1.2.3",
+    "loader-utils": "^1.2.3",
     "postcss": "7.0.36",
     "rework": "1.0.1",
     "rework-visit": "1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -382,11 +382,6 @@ duplexer@^0.1.1:
   resolved "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
   integrity sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=
 
-emojis-list@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
-  integrity sha1-TapNnbAPmBmIDHn6RXrlsJof04k=
-
 emojis-list@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78"
@@ -917,13 +912,13 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   resolved "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
   integrity sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==
 
-loader-utils@1.2.3:
-  version "1.2.3"
-  resolved "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz#1ff5dc6911c9f0a062531a4c04b609406108c2c7"
-  integrity sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==
+loader-utils@^1.2.3:
+  version "1.4.2"
+  resolved "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz#29a957f3a63973883eb684f10ffd3d151fec01a3"
+  integrity sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==
   dependencies:
     big.js "^5.2.2"
-    emojis-list "^2.0.0"
+    emojis-list "^3.0.0"
     json5 "^1.0.1"
 
 loader-utils@^2.0.0:


### PR DESCRIPTION
### Context

`resolve-url-loader` version 3 has a dependency on `loader-utils` version 1.2.3. There are multiple CVEs against `loader-utils` version 1.2.3. It'd be awesome allow upgrading to a version that includes security patches!

* CVE-2022-37599 - https://nvd.nist.gov/vuln/detail/CVE-2022-37599
* CVE-2022-37601 - https://nvd.nist.gov/vuln/detail/CVE-2022-37601
* CVE-2022-37603 - https://nvd.nist.gov/vuln/detail/CVE-2022-37603


### Change

Loosen the constraints on the version of `loader-utils` to any major version 1, 1.2.3 or above.

This should maintain compatibility.