### PR TITLE
Configure CI for the v3-maintenance branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,39 @@
+name: ci
+on:
+  - push
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    continue-on-error: true
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+        node:
+          - '12.x'
+          - '14.x'
+          - 'lts/*'
+        band:
+          - 'webpack4'
+          - 'webpack5'
+    steps:
+        - name: Use OS ${{ matrix.os }}
+          uses: actions/checkout@v3
+        - name: Use Node@${{ matrix.node }}
+          uses: actions/setup-node@v2
+          with:
+            node-version: ${{ matrix.node }}
+            cache: 'yarn'
+        - name: Install Dependencies
+          run: yarn install
+        - name: Lint js
+          run: yarn lint
+        - name: Unit test
+          run: yarn test:unit
+        - name: End-to-End test ${{ matrix.band }}
+          if: ${{ !(matrix.node == 'lts/*' && matrix.band == 'webpack4') }}
+          run: yarn test:e2e
+          env:
+            ONLY: '${{ matrix.band }}*'


### PR DESCRIPTION
To ease the maintenance burden. Run CI on the `v3-maintenance` branch to help prove its quality.

This passes on my fork: https://github.com/orien/resolve-url-loader/actions/runs/3599131910